### PR TITLE
patch for bug "two models with the same name"

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -26,9 +26,9 @@ except NameError:
 
 
 class TaggableRel(ManyToManyRel):
-    def __init__(self, to):
+    def __init__(self, to, related_name=None):
         self.to = to
-        self.related_name = None
+        self.related_name = related_name
         self.limit_choices_to = {}
         self.symmetrical = True
         self.multiple = True
@@ -37,10 +37,10 @@ class TaggableRel(ManyToManyRel):
 
 class TaggableManager(RelatedField):
     def __init__(self, verbose_name=_("Tags"),
-        help_text=_("A comma-separated list of tags."), through=None, blank=False):
+        help_text=_("A comma-separated list of tags."), through=None, blank=False, related_name=None):
         self.use_gfk = through is None or issubclass(through, GenericTaggedItemBase)
         self.through = through or TaggedItem
-        self.rel = TaggableRel(to=self.through._meta.get_field("tag").rel.to)
+        self.rel = TaggableRel(to=self.through._meta.get_field("tag").rel.to, related_name=related_name)
         self.verbose_name = verbose_name
         self.help_text = help_text
         self.blank = blank
@@ -142,10 +142,10 @@ class _TaggableManager(models.Manager):
             name__in=str_tags
         )
         tag_objs.update(existing)
-        
+
         for new_tag in str_tags - set(t.name for t in existing):
             tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
-        
+
         for tag in tag_objs:
             self.through.objects.get_or_create(tag=tag, **self._lookup_kwargs())
 


### PR DESCRIPTION
Hi,

this is a patch for the case that two tagged models are named equal.

Details: 

I've got a project with photologue and taggit.tests installed. Bot have a model called "Photo" which can be tagged. When testing taggit in the context of the project, I receive the following error:

Error: One or more models did not validate:
tests.photo: Accessor for m2m field 'tags' clashes with related m2m field 'Tag.photo_set'. Add a related_name argument to the definition for 'tags'.
tests.photo: Accessor for m2m field 'tagged_items' clashes with related m2m field 'TaggedItem.photo_set'. Add a related_name argument to the definition for 'tagged_items'.
photologue.photo: Accessor for m2m field 'tags' clashes with related m2m field 'Tag.photo_set'. Add a related_name argument to the definition for 'tags'.
photologue.photo: Accessor for m2m field 'tagged_items' clashes with related m2m field 'TaggedItem.photo_set'. Add a related_name argument to the definition for 'tagged_items'.

This patch solves this problem with a related-name attribute for the TaggableManager.

Regards
Julian
