### PR TITLE
built-in view doesn't work for custom tagging

### DIFF
--- a/taggit/views.py
+++ b/taggit/views.py
@@ -5,13 +5,17 @@ from django.views.generic.list_detail import object_list
 from taggit.models import TaggedItem, Tag
 
 
-def tagged_object_list(request, slug, queryset, **kwargs):
+def tagged_object_list(request, slug, queryset, through=None, **kwargs):
     if callable(queryset):
         queryset = queryset()
     tag = get_object_or_404(Tag, slug=slug)
-    qs = queryset.filter(pk__in=TaggedItem.objects.filter(
-        tag=tag, content_type=ContentType.objects.get_for_model(queryset.model)
-    ).values_list("object_id", flat=True))
+    if through is not None:
+        qs = queryset.filter(pk__in=through.objects.filter(tag=tag
+                ).values_list("content_object_id", flat=True))
+    else:
+        qs = queryset.filter(pk__in=TaggedItem.objects.filter(tag=tag,
+                content_type=ContentType.objects.get_for_model(queryset.model)
+                ).values_list("object_id", flat=True))
     if "extra_context" not in kwargs:
         kwargs["extra_context"] = {}
     kwargs["extra_context"]["tag"] = tag


### PR DESCRIPTION
Attached patch adds a `through` argument to the view to be used when performing the query.
