### PR TITLE
Added names method to _TaggableManager

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -149,6 +149,9 @@ class _TaggableManager(models.Manager):
     def get_query_set(self):
         return self.through.tags_for(self.model, self.instance)
 
+    def names(self):
+        return (tag.name for tag in self.get_query_set())
+
     def _lookup_kwargs(self):
         return self.through.lookup_kwargs(self.instance)
 


### PR DESCRIPTION
The method returns a (generator) list of just the tag names, so you can do things like this:

if "my_tag" in obj.tags.names():
   # Etc

This is much easier than other methods.
