### PR TITLE
Fix for django 1.5 in taggit.views.tagged_object_list

### DIFF
--- a/taggit/views.py
+++ b/taggit/views.py
@@ -1,6 +1,8 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
-from django.views.generic.list_detail import object_list
+#this does not work anymore in django 1.5, see also: https://docs.djangoproject.com/en/1.4/topics/generic-views-migration/
+#from django.views.generic.list_detail import object_list
+from django.views.generic.list import ListView
 
 from taggit.models import TaggedItem, Tag
 
@@ -15,4 +17,6 @@ def tagged_object_list(request, slug, queryset, **kwargs):
     if "extra_context" not in kwargs:
         kwargs["extra_context"] = {}
     kwargs["extra_context"]["tag"] = tag
-    return object_list(request, qs, **kwargs)
+    #return object_list(request, qs, **kwargs)
+    return ListView.as_view(request, qs, **kwargs)
+


### PR DESCRIPTION
from django.views.generic.list_detail import object_list will not work anymore in django 1.5
