### PR TITLE
#131 fix for new related fields in django

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -44,10 +44,8 @@ class TaggableManager(RelatedField):
         self.help_text = help_text
         self.blank = blank
         self.editable = True
-        self.unique = False
         self.creates_table = False
         self.db_column = None
-        self.choices = None
         self.serialize = False
         self.null = True
         self.creation_counter = models.Field.creation_counter
@@ -139,6 +137,14 @@ class TaggableManager(RelatedField):
 
     def bulk_related_objects(self, new_objs, using):
         return []
+
+    @property
+    def unique(self):
+        return False
+
+    @property
+    def choices(self):
+        return None
 
 
 class _TaggableManager(models.Manager):


### PR DESCRIPTION
use unique and choices properties instead attributes for future django compatibility. See https://github.com/alex/django-taggit/issues/131
