### PR TITLE
Added names() method to _TaggableManager

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -60,9 +60,15 @@ playing around with the API.
         just an iterable) containing the name of each tag as a string::
 
             >>> apple.tags.names()
-            [u'green', u'red']
-            >>> 'green' in apple.tags.names()
-            True
+            [u'green and juicy', u'red']
+
+    .. method:: slugs()
+
+        Convenience method, returning a ``ValuesListQuerySet`` (basically
+        just an iterable) containing the slug of each tag as a string::
+
+            >>> apple.slugs.names()
+            [u'green-and-juicy', u'red']
 
 Filtering
 ~~~~~~~~~

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -176,6 +176,10 @@ class _TaggableManager(models.Manager):
         return self.get_query_set().values_list('name', flat=True)
 
     @require_instance_manager
+    def slugs(self):
+        return self.get_query_set().values_list('slug', flat=True)
+
+    @require_instance_manager
     def set(self, *tags):
         self.clear()
         self.add(*tags)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -319,6 +319,12 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         apple.tags.add('red')
         self.assertEqual(list(apple.tags.names()), ['green', 'red'])
 
+    def test_slugs_method(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add('green and juicy')
+        apple.tags.add('red')
+        self.assertEqual(list(apple.tags.slugs()), ['green-and-juicy', 'red'])
+
 
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     food_model = DirectFood


### PR DESCRIPTION
The method returns a (generator) list of just the tag names, so you can do things like this:

``` python
if "my_tag" in obj.tags.names():
    # etc
```

This is much easier than other methods.

I originally submitted this as https://github.com/alex/django-taggit/pull/100 but accidentally deleted my repo. This time I've also added tests and used `values_list` like suggested.
