### PR TITLE
For the default Tag implementation, order by name.

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -55,6 +55,7 @@ class TagBase(models.Model):
 
 class Tag(TagBase):
     class Meta:
+        ordering = ['name']
         verbose_name = _("Tag")
         verbose_name_plural = _("Tags")
 


### PR DESCRIPTION
Seems like the intuitive choice to me. When displaying tags, I always want them ordered alphabetically.
