### PR TITLE
Set TagBase's name field as well when resolving duplicate entries.

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -35,12 +35,10 @@ class TagBase(models.Model):
             while True:
                 i += 1
                 try:
-                    sid = transaction.savepoint(**trans_kwargs)
-                    res = super(TagBase, self).save(*args, **kwargs)
-                    transaction.savepoint_commit(sid, **trans_kwargs)
-                    return res
+                    with transaction.atomic(**trans_kwargs):
+                        res = super(TagBase, self).save(*args, **kwargs)
+                        return res
                 except IntegrityError:
-                    transaction.savepoint_rollback(sid, **trans_kwargs)
                     self.slug = self.slugify(self.name, i)
                     self.name = '%s_%d' % (self.name, i)
         else:


### PR DESCRIPTION
IntegrityErrors only get auto-resolved by adding a numeric value in both the slug and the name field, since they both are defined to be unique. This change fixes an infinite loop (in MySQL with InnoDB as the storage engine).

(Probably) fixes https://github.com/alex/django-taggit/issues/174. Tests are passing with MySQL/InnoDB now and never finished running before. With sqlite3 as the storage engine, the tests are passing as they did before.
