### PR TITLE
Duplicate Tag model name has problems when accessed directly

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -57,6 +57,13 @@ class BaseTaggingTransactionTestCase(TransactionTestCase, BaseTaggingTest):
     pass
 
 
+class TagModelDirectAccess(TestCase):
+
+    def test_unique_name(self):
+        Tag.objects.create(name='Hello')
+        Tag.objects.create(name='Hello')
+
+
 class TagModelTestCase(BaseTaggingTransactionTestCase):
     food_model = Food
     tag_model = Tag


### PR DESCRIPTION
Test triggers infinite loop on Django 1.4, 1.5
Raises TransactionManagementError on Django 1.6

This is due to IntegrityError is triggered by name column, not slug (TagBase.save)

I haven't come up with a elegant solution to this problem. Any suggestions?
