### PR TITLE
remember to set attname if django < 1.7

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -92,7 +92,7 @@ class TaggableManager(RelatedField, Field):
 
     def contribute_to_class(self, cls, name):
         if VERSION < (1, 7):
-            self.name = self.column = name
+            self.name = self.column = self.attname = name
         else:
             self.set_attributes_from_name(name)
         self.model = cls


### PR DESCRIPTION
In django < 1.7, TaggableManager's `_get_val_from_obj()` method will raise an Attribute error if attname is not set
