### PR TITLE
ENH: Allow specification of tag delimiter

### DIFF
--- a/taggit/utils.py
+++ b/taggit/utils.py
@@ -1,21 +1,26 @@
 from __future__ import unicode_literals
 
+import re
+
 from django.conf import settings
 
 from django.utils.encoding import force_text
 from django.utils.functional import wraps
-from django.utils import six
 
 
-TAG_DELIMITER = getattr(settings, 'TAGGIT_TAG_DELIMITER', ',')
+# Regular expression that will split tag on spaces, except when the tag is
+# surrounded by quotation marks.
+DEFAULT_TAG_DELIMITER = r"(?: |\"(.*?)\"|'.*?'),?"
+TAG_DELIMITER = getattr(settings, 'TAGGIT_TAG_DELIMITER',
+                        DEFAULT_TAG_DELIMITER)
 TAG_SEPARATOR = getattr(settings, 'TAGGIT_TAG_SEPARATOR', ', ')
 
 
-def parse_tags(tagstring):
+def parse_tags(tagstring, tag_delimiter=TAG_DELIMITER):
     """
-    Parses tag input, with multiple word input being activated and
-    delineated by commas and double quotes. Quotes take precedence, so
-    they may contain commas.
+    Parses tag input, with default behavior of multiple word input being
+    activated and delineated by commas and double quotes. Quotes take
+    precedence, so they may contain commas.
 
     Returns a sorted list of unique tag names.
 
@@ -27,60 +32,11 @@ def parse_tags(tagstring):
 
     tagstring = force_text(tagstring)
 
-    # Special case - if there are no commas or double quotes in the
-    # input, we don't *do* a recall... I mean, we know we only need to
-    # split on spaces.
-    if ',' not in tagstring and '"' not in tagstring:
-        words = list(set(split_strip(tagstring, ' ')))
-        words.sort()
-        return words
-
-    words = []
-    buffer = []
-    # Defer splitting of non-quoted sections until we know if there are
-    # any unquoted commas.
-    to_be_split = []
-    saw_loose_comma = False
-    open_quote = False
-    i = iter(tagstring)
-    try:
-        while True:
-            c = six.next(i)
-            if c == '"':
-                if buffer:
-                    to_be_split.append(''.join(buffer))
-                    buffer = []
-                # Find the matching quote
-                open_quote = True
-                c = six.next(i)
-                while c != '"':
-                    buffer.append(c)
-                    c = six.next(i)
-                if buffer:
-                    word = ''.join(buffer).strip()
-                    if word:
-                        words.append(word)
-                    buffer = []
-                open_quote = False
-            else:
-                if not saw_loose_comma and c == ',':
-                    saw_loose_comma = True
-                buffer.append(c)
-    except StopIteration:
-        # If we were parsing an open quote which was never closed treat
-        # the buffer as unquoted.
-        if buffer:
-            if open_quote and ',' in buffer:
-                saw_loose_comma = True
-            to_be_split.append(''.join(buffer))
-    if to_be_split:
-        if saw_loose_comma:
-            delimiter = ','
-        else:
-            delimiter = ' '
-        for chunk in to_be_split:
-            words.extend(split_strip(chunk, delimiter))
-    words = list(set(words))
+    # The default regex pattern will return each whitespace as a token, so we
+    # need to discard all whitespace tokens, keeping only the  as a
+    splitter = re.compile(TAG_DELIMITER)
+    words = set(w for w in splitter.split(tagstring) if w)
+    words = list(words)
     words.sort()
     return words
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -539,3 +539,7 @@ class TagStringParseTestCase(UnitTestCase):
         self.assertEqual(edit_string_for_tags([plain, spaces, comma]), '"com,ma", plain, spa ces')
         self.assertEqual(edit_string_for_tags([plain, comma]), '"com,ma", plain')
         self.assertEqual(edit_string_for_tags([comma, spaces]), '"com,ma", spa ces')
+
+    def test_with_custom_separator(self):
+        self.assertEqual(parse_tags('Cued Speech, people, adaptations'),
+                         ['adaptations', 'Cued Speech', 'people'])


### PR DESCRIPTION
Users can now specify tag delimiter in the settings file (defaults to
comma) and separator (defaults to comma plus space).  If the delimiter
is present in the tag, then the tag is surrounded by quotation marks.

This is a small API change from before (when rendering existing tags,
the quotation marks used to be added to tags with spaces; however, this
is uncessary so I think it's best to add quotation marks only when the
tag contains the delimiter).  This makes the rendering more uniform in
the UI (e.g. when users are adding new tags, they may not always add the
quotation marks and might be surprised when the save and then go back to
edit the form and see quotation marks have been added).
