### PR TITLE
Fix a typo in documentation

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -18,7 +18,7 @@ tagging to your project easy and fun.
    Since version 0.12.0 taggit uses Django migrations by default. South users
    have to adjust their settings::
 
-      SOUTH_MIGRATIONS_MODULES = {
+      SOUTH_MIGRATION_MODULES = {
           'taggit': 'taggit.south_migrations',
       }
 


### PR DESCRIPTION
Hello,

Small typo in the documentation that have make me lost 10min trying to figuring out why this wasn't working.

Kind regards,
