### PR TITLE
Added support for custom AUTH_USER_MODEL

### DIFF
--- a/taggit/migrations/0001_initial.py
+++ b/taggit/migrations/0001_initial.py
@@ -1,5 +1,6 @@
 # encoding: utf8
 from __future__ import unicode_literals
+from django.conf import settings
 from django.db import models, migrations
 
 
@@ -7,6 +8,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '__first__'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
     operations = [


### PR DESCRIPTION
Running migrations in a project that defines a custom user model results
in the error:

```
ValueError: Lookup failed for model referenced by field admin.LogEntry.user: accounts.User
```

More about the issue can be found at
https://code.djangoproject.com/ticket/22563.

Adding the `swappable_dependency()` dependency solves the issue allowing
the migration to run successfully.
