### PR TITLE
Fix `add` to handle integer values (casted to string) (IntegrityError: UNIQUE constraint failed)

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -132,10 +132,13 @@ class _TaggableManager(models.Manager):
         str_tags = set()
         tag_objs = set()
         for t in tags:
-            if not isinstance(t, self.through.tag_model()):
-                str_tags.add(str(t))
-            else:
+            if isinstance(t, self.through.tag_model()):
                 tag_objs.add(t)
+            elif isinstance(t, six.string_types):
+                str_tags.add(t)
+            else:
+                raise ValueError("Cannot add {0} ({1}). Expected {2} or str.".format(
+                    t, type(t), type(self.through.tag_model())))
 
         # If str_tags has 0 elements Django actually optimizes that to not do a
         # query.  Malcolm is very smart.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -88,10 +88,12 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
         ], attr="slug")
 
     def test_integers(self):
+        """Adding an integer as a tag should raise a ValueError (#237)."""
         apple = self.food_model.objects.create(name="apple")
-        orange = self.food_model.objects.create(name="orange")
-        apple.tags.add(1)
-        orange.tags.add(1)
+        with self.assertRaisesRegexp(ValueError, (
+                r"Cannot add 1 \(<(type|class) 'int'>\). "
+                r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
+            apple.tags.add(1)
 
 class TagModelDirectTestCase(TagModelTestCase):
     food_model = DirectFood


### PR DESCRIPTION
Handle non-string (integer) input to `add`, by casting it to a string,
and build up `str_tags` and `tag_objs` in a single loop.

This fixes the following error (from the added test):

```
Traceback (most recent call last):
  File "venv/src/django-taggit/tests/tests.py", line 94, in test_integers
    orange.tags.add(1)
  File "venv/src/django-taggit/taggit/utils.py", line 128, in inner
    return func(self, *args, **kwargs)
  File "venv/src/django-taggit/taggit/managers.py", line 145, in add
    tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
  File "venv/lib/python2.7/site-packages/django/db/models/manager.py", line 157, in create
    return self.get_queryset().create(**kwargs)
  File "venv/lib/python2.7/site-packages/django/db/models/query.py", line 322, in create
    obj.save(force_insert=True, using=self.db)
  File "venv/src/django-taggit/taggit/models.py", line 71, in save
    return super(TagBase, self).save(*args, **kwargs)
  File "venv/lib/python2.7/site-packages/django/db/models/base.py", line 545, in save
    force_update=force_update, update_fields=update_fields)
  File "venv/lib/python2.7/site-packages/django/db/models/base.py", line 573, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "venv/lib/python2.7/site-packages/django/db/models/base.py", line 654, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "venv/lib/python2.7/site-packages/django/db/models/base.py", line 687, in _do_insert
    using=using, raw=raw)
  File "venv/lib/python2.7/site-packages/django/db/models/manager.py", line 232, in _insert
    return insert_query(self.model, objs, fields, **kwargs)
  File "venv/lib/python2.7/site-packages/django/db/models/query.py", line 1514, in insert_query
    return query.get_compiler(using=using).execute_sql(return_id)
  File "venv/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 903, in execute_sql
    cursor.execute(sql, params)
  File "venv/lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
  File "venv/lib/python2.7/site-packages/django/db/utils.py", line 99, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "venv/lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
  File "venv/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py", line 451, in execute
    return Database.Cursor.execute(self, query, params)
IntegrityError: UNIQUE constraint failed: tests_officialtag.name
```
