### PR TITLE
Added __str__ implementation to _TaggableManager

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 from operator import attrgetter
 
 from django import VERSION
+from django.utils.encoding import python_2_unicode_compatible
+
 try:
     from django.contrib.contenttypes.fields import GenericRelation
 except ImportError:  # django < 1.7
@@ -72,6 +74,7 @@ class ExtraJoinRestriction(object):
         return self.__class__(self.alias, self.col, self.content_types[:])
 
 
+@python_2_unicode_compatible
 class _TaggableManager(models.Manager):
     def __init__(self, through, model, instance, prefetch_cache_name):
         self.through = through
@@ -214,6 +217,12 @@ class _TaggableManager(models.Manager):
             obj.similar_tags = result["n"]
             results.append(obj)
         return results
+
+    def __str__(self):
+        model = self.model
+        app = model._meta.app_label
+        return '%s.%s.%s' % (app, model._meta.object_name, self.prefetch_cache_name)
+
 
 
 class TaggableManager(RelatedField, Field):


### PR DESCRIPTION
When coercing a TaggableManager descriptor to a string in Django 1.7, a StopIteration exception is raised since the base Manager **str** method assumes the manager class is an a normal manager:

```
def __str__(self):
    """ Return "app_label.model_label.manager_name". """
    model = self.model
    opts = model._meta
    app = model._meta.app_label
    manager_name = next(name for (_, name, manager)
        in opts.concrete_managers + opts.abstract_managers
        if manager == self)
    return '%s.%s.%s' % (app, model._meta.object_name, manager_name)
```

This PR simply attempts to implement the same outcome as the parent class by assuming that `manager_name` is the `prefix_cache_name` passed to the manager's constructor.
