### PR TITLE
Fixed error when adding tags to user model with name of Name

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -522,7 +522,10 @@ class TaggableManager(RelatedField, Field):
         return self.through.objects.none()
 
     def related_query_name(self):
-        return self.model._meta.model_name
+        if self.remote_field.related_name:
+            return self.remote_field.related_name
+        else:
+            return self.model._meta.model_name
 
     def m2m_reverse_name(self):
         return self.through._meta.get_field('tag').column


### PR DESCRIPTION
The related_query_name function was using the model name instead of the related_name attribute which was causing a clash between the model name and the tag.name.  By returning the field's related name instead of the model name  when it exists, fixed this problem.