### PR TITLE
small patch for managers.py

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -81,6 +81,7 @@ class _TaggableManager(models.Manager):
     def __init__(self, through, model, instance, prefetch_cache_name):
         self.through = through
         self.model = model
+        self.name = prefetch_cache_name
         self.instance = instance
         self.prefetch_cache_name = prefetch_cache_name
         self._db = None


### PR DESCRIPTION
Django 1.11.
Without name field in init we have an error: '_TaggableManager' object has no attribute 'name' 

class C(models.Model):
    ...
    tags = TaggableManager()
    ...

    def get_fields_with_value(self):
        return ((f, getattr(self, f, None)) for f in self.get_fields())