### PR TITLE
Moved TaggedItemBase.tags_for() to ItemBase.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+~~~~~~~~~~
+
+* Moved TaggedItemBase.tags_for() to ItemBase.
+
 1.1.0 (2019-03-22)
 ~~~~~~~~~~~~~~~~~~
 

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -102,15 +102,6 @@ class ItemBase(models.Model):
     def lookup_kwargs(cls, instance):
         return {"content_object": instance}
 
-
-class TaggedItemBase(ItemBase):
-    tag = models.ForeignKey(
-        Tag, related_name="%(app_label)s_%(class)s_items", on_delete=models.CASCADE
-    )
-
-    class Meta:
-        abstract = True
-
     @classmethod
     def tags_for(cls, model, instance=None, **extra_filters):
         kwargs = extra_filters or {}
@@ -119,6 +110,15 @@ class TaggedItemBase(ItemBase):
             return cls.tag_model().objects.filter(**kwargs)
         kwargs.update({"%s__content_object__isnull" % cls.tag_relname(): False})
         return cls.tag_model().objects.filter(**kwargs).distinct()
+
+
+class TaggedItemBase(ItemBase):
+    tag = models.ForeignKey(
+        Tag, related_name="%(app_label)s_%(class)s_items", on_delete=models.CASCADE
+    )
+
+    class Meta:
+        abstract = True
 
 
 class CommonGenericTaggedItemBase(ItemBase):

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -112,6 +112,36 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name="DirectTrackedFood",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="DirectTrackedPet",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=50)),
+            ],
+        ),
+        migrations.CreateModel(
             name="BlankTagModel",
             fields=[
                 (
@@ -288,6 +318,35 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name="TrackedTag",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(max_length=100, unique=True, verbose_name="Name"),
+                ),
+                (
+                    "slug",
+                    models.SlugField(max_length=100, unique=True, verbose_name="Slug"),
+                ),
+                ("created_by", models.CharField(max_length=50)),
+                ("created_dt", models.DateTimeField(auto_now_add=True)),
+                (
+                    "description",
+                    models.TextField(blank=True, max_length=255, null=True),
+                ),
+            ],
+            options={"abstract": False},
+        ),
+        migrations.CreateModel(
             name="Parent",
             fields=[
                 (
@@ -434,6 +493,46 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 )
+            ],
+            options={"abstract": False},
+        ),
+        migrations.CreateModel(
+            name="TaggedTrackedFood",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "content_object",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tests.DirectTrackedFood",
+                    ),
+                ),
+                ("created_by", models.CharField(max_length=50)),
+                ("created_dt", models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="TaggedTrackedPet",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_by", models.CharField(max_length=50)),
+                ("created_dt", models.DateTimeField(auto_now_add=True)),
             ],
             options={"abstract": False},
         ),
@@ -702,6 +801,24 @@ class Migration(migrations.Migration):
             ],
             bases=("tests.officialpet",),
         ),
+        migrations.CreateModel(
+            name="DirectTrackedHousePet",
+            fields=[
+                (
+                    "directtrackedpet_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="tests.DirectTrackedPet",
+                    ),
+                ),
+                ("trained", models.BooleanField(default=False)),
+            ],
+            bases=("tests.directtrackedpet",),
+        ),
         migrations.AddField(
             model_name="uuidfood",
             name="tags",
@@ -762,6 +879,31 @@ class Migration(migrations.Migration):
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name="tests_taggedfood_items",
                 to="taggit.Tag",
+            ),
+        ),
+        migrations.AddField(
+            model_name="taggedtrackedpet",
+            name="content_object",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE, to="tests.DirectTrackedPet"
+            ),
+        ),
+        migrations.AddField(
+            model_name="taggedtrackedpet",
+            name="tag",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="tests_taggedtrackedpet_items",
+                to="tests.TrackedTag",
+            ),
+        ),
+        migrations.AddField(
+            model_name="taggedtrackedfood",
+            name="tag",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="tests_taggedtrackedfood_items",
+                to="tests.TrackedTag",
             ),
         ),
         migrations.AddField(
@@ -945,6 +1087,26 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.AddField(
+            model_name="directtrackedpet",
+            name="tags",
+            field=taggit.managers.TaggableManager(
+                help_text="A comma-separated list of tags.",
+                through="tests.TaggedTrackedPet",
+                to="tests.TrackedTag",
+                verbose_name="Tags",
+            ),
+        ),
+        migrations.AddField(
+            model_name="directtrackedfood",
+            name="tags",
+            field=taggit.managers.TaggableManager(
+                help_text="A comma-separated list of tags.",
+                through="tests.TaggedTrackedFood",
+                to="tests.TrackedTag",
+                verbose_name="Tags",
+            ),
+        ),
+        migrations.AddField(
             model_name="directcustompkpet",
             name="tags",
             field=taggit.managers.TaggableManager(
@@ -1006,6 +1168,9 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name="taggedfood", unique_together={("content_object", "tag")}
+        ),
+        migrations.AlterUniqueTogether(
+            name="taggedtrackedfood", unique_together={("content_object", "tag")}
         ),
         migrations.AlterUniqueTogether(
             name="taggedcustompkpet", unique_together={("content_object", "tag")}

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,6 +7,7 @@ from taggit.models import (
     CommonGenericTaggedItemBase,
     GenericTaggedItemBase,
     GenericUUIDTaggedItemBase,
+    ItemBase,
     Tag,
     TagBase,
     TaggedItem,
@@ -102,6 +103,58 @@ class DirectPet(models.Model):
 
 
 class DirectHousePet(DirectPet):
+    trained = models.BooleanField(default=False)
+
+
+# Test direct-tagging with custom through model and custom tag
+
+
+class TrackedTag(TagBase):
+    created_by = models.CharField(max_length=50)
+    created_dt = models.DateTimeField(auto_now_add=True)
+    description = models.TextField(blank=True, max_length=255, null=True)
+
+
+class TaggedTrackedFood(ItemBase):
+    content_object = models.ForeignKey("DirectTrackedFood", on_delete=models.CASCADE)
+    tag = models.ForeignKey(
+        TrackedTag, on_delete=models.CASCADE, related_name="%(class)s_items"
+    )
+    created_by = models.CharField(max_length=50)
+    created_dt = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ["content_object", "tag"]
+
+
+class TaggedTrackedPet(ItemBase):
+    content_object = models.ForeignKey("DirectTrackedPet", on_delete=models.CASCADE)
+    tag = models.ForeignKey(
+        TrackedTag, on_delete=models.CASCADE, related_name="%(class)s_items"
+    )
+    created_by = models.CharField(max_length=50)
+    created_dt = models.DateTimeField(auto_now_add=True)
+
+
+class DirectTrackedFood(models.Model):
+    name = models.CharField(max_length=50)
+
+    tags = TaggableManager(through=TaggedTrackedFood)
+
+    def __str__(self):
+        return self.name
+
+
+class DirectTrackedPet(models.Model):
+    name = models.CharField(max_length=50)
+
+    tags = TaggableManager(through=TaggedTrackedPet)
+
+    def __str__(self):
+        return self.name
+
+
+class DirectTrackedHousePet(DirectTrackedPet):
     trained = models.BooleanField(default=False)
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,6 +28,9 @@ from .models import (
     DirectFood,
     DirectHousePet,
     DirectPet,
+    DirectTrackedFood,
+    DirectTrackedHousePet,
+    DirectTrackedPet,
     Food,
     HousePet,
     Movie,
@@ -43,6 +46,8 @@ from .models import (
     TaggedCustomPK,
     TaggedCustomPKFood,
     TaggedFood,
+    TaggedTrackedFood,
+    TrackedTag,
     UUIDFood,
     UUIDTag,
 )
@@ -735,6 +740,14 @@ class TaggableManagerDirectTestCase(TaggableManagerTestCase):
     pet_model = DirectPet
     housepet_model = DirectHousePet
     taggeditem_model = TaggedFood
+
+
+class TaggableManagerDirectTrackedTestCase(TaggableManagerTestCase):
+    food_model = DirectTrackedFood
+    pet_model = DirectTrackedPet
+    housepet_model = DirectTrackedHousePet
+    taggeditem_model = TaggedTrackedFood
+    tag_model = TrackedTag
 
 
 class TaggableManagerDirectCustomPKTestCase(TaggableManagerTestCase):


### PR DESCRIPTION
`ItemBase.tags_for()` was moved to `TaggedItemBase` in 998ef2f as part of a fix to avoid direct reference to the default `Tag` model. The change made use of `ItemBase.tag_model()` instead so moving `ItemBase.tags_for()` was unnecessary and makes subclassing `ItemBase` more difficult.

Fixes #101.