### PR TITLE
Remove py35-djangomaster from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,11 @@ matrix:
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
-    - python: 3.5
-      env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
   allow_failures:
-    - env: TOXENV=py35-djangomaster
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py{34,35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37}-django22
-    py{35,36,37}-djangomaster
+    py{36,37}-djangomaster
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.5 support was removed from Django in
https://github.com/django/django/commit/7e6b214ed34f5562dbd83cf54924a5b589a29715.