### PR TITLE
Make TaggedItem unique

### DIFF
--- a/taggit/migrations/0003_taggeditem_add_unique_index.py
+++ b/taggit/migrations/0003_taggeditem_add_unique_index.py
@@ -6,11 +6,13 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
 
-    dependencies = [("taggit", "0002_auto_20150616_2121")]
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("taggit", "0002_auto_20150616_2121"),
+    ]
 
     operations = [
         migrations.AlterUniqueTogether(
-            name="taggeditem",
-            unique_together=set([("content_type", "object_id", "tag_id")]),
+            name="taggeditem", unique_together={("content_type", "object_id", "tag")}
         )
     ]

--- a/taggit/migrations/0003_taggeditem_add_unique_index.py
+++ b/taggit/migrations/0003_taggeditem_add_unique_index.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("taggit", "0002_auto_20150616_2121")]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="taggeditem",
+            unique_together=set([("content_type", "object_id", "tag_id")]),
+        )
+    ]

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -176,3 +176,4 @@ class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
         verbose_name_plural = _("Tagged Items")
         app_label = "taggit"
         index_together = [["content_type", "object_id"]]
+        unique_together = [["content_type", "object_id", "tag"]]

--- a/tests/migrations/0003_add_unique_indexes.py
+++ b/tests/migrations/0003_add_unique_indexes.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("tests", "0002_uuid_models"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="taggedfood", unique_together={("content_object", "tag")}
+        ),
+        migrations.AlterUniqueTogether(
+            name="taggedcustompkfood", unique_together={("content_object", "tag")}
+        ),
+        migrations.AlterUniqueTogether(
+            name="taggedcustompkpet", unique_together={("content_object", "tag")}
+        ),
+        migrations.AlterUniqueTogether(
+            name="taggedcustompk", unique_together={("object_id", "tag")}
+        ),
+        migrations.AlterUniqueTogether(
+            name="officialthroughmodel",
+            unique_together={("content_type", "object_id", "tag")},
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -71,6 +71,9 @@ class HousePet(Pet):
 class TaggedFood(TaggedItemBase):
     content_object = models.ForeignKey("DirectFood", on_delete=models.CASCADE)
 
+    class Meta:
+        unique_together = [["content_object", "tag"]]
+
 
 class TaggedPet(TaggedItemBase):
     content_object = models.ForeignKey("DirectPet", on_delete=models.CASCADE)
@@ -106,9 +109,15 @@ class DirectHousePet(DirectPet):
 class TaggedCustomPKFood(TaggedItemBase):
     content_object = models.ForeignKey("DirectCustomPKFood", on_delete=models.CASCADE)
 
+    class Meta:
+        unique_together = [["content_object", "tag"]]
+
 
 class TaggedCustomPKPet(TaggedItemBase):
     content_object = models.ForeignKey("DirectCustomPKPet", on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = [["content_object", "tag"]]
 
 
 @python_2_unicode_compatible
@@ -137,6 +146,9 @@ class DirectCustomPKHousePet(DirectCustomPKPet):
 # Test custom through model to model with custom PK using GenericForeignKey
 class TaggedCustomPK(CommonGenericTaggedItemBase, TaggedItemBase):
     object_id = models.CharField(max_length=50, verbose_name="Object id", db_index=True)
+
+    class Meta:
+        unique_together = [["object_id", "tag"]]
 
 
 @python_2_unicode_compatible
@@ -174,6 +186,9 @@ class OfficialThroughModel(GenericTaggedItemBase):
     tag = models.ForeignKey(
         OfficialTag, related_name="tagged_items", on_delete=models.CASCADE
     )
+
+    class Meta:
+        unique_together = [["content_type", "object_id", "tag"]]
 
 
 @python_2_unicode_compatible

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -788,9 +788,6 @@ class TaggableManagerInitializationTestCase(TaggableManagerTestCase):
     def test_custom_manager(self):
         self.assertEqual(self.custom_manager_model.tags.__class__, CustomManager.Foo)
 
-    def test_tag_uniqueness(self):
-        pass
-
 
 class TaggableFormTestCase(BaseTaggingTestCase):
     form_class = FoodForm


### PR DESCRIPTION
Prevents duplication of a`TaggedItem` on a race condition at this line:
https://github.com/jazzband/django-taggit/blob/7cea0b2d7af23d7c0e04f52d60abf3dd175cb26d/taggit/managers.py#L158-L160
 
The `kwargs` used in a `get_or_create` must be unique at the database level.

Fixes #349.