### PR TITLE
Ignore .venv for lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build/
 .tox/
 .coverage
 .eggs/
+.venv/

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ ignore = E501
 exclude =
     .tox
     docs
+    .venv
 
 [isort]
 combine_as_imports = True
@@ -18,3 +19,4 @@ multi_line_output = 3
 not_skip = __init__.py
 skip =
     .tox
+    .venv


### PR DESCRIPTION
As a rule of thumb.