### PR TITLE
Workaround KeyError in similar_objects

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -377,9 +377,7 @@ class _TaggableManager(models.Manager):
         results = []
         for result in qs:
             try:
-                obj = items[
-                    tuple(result[k] for k in lookup_keys)
-                ]
+                obj = items[tuple(result[k] for k in lookup_keys)]
             except KeyError:
                 # This sometimes happens, for reasons unkown
                 # see GH issue #80

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -376,7 +376,14 @@ class _TaggableManager(models.Manager):
 
         results = []
         for result in qs:
-            obj = items[tuple(result[k] for k in lookup_keys)]
+            try:
+                obj = items[
+                    tuple(result[k] for k in lookup_keys)
+                ]
+            except KeyError:
+                # This sometimes happens, for reasons unkown
+                # see GH issue #80
+                continue
             obj.similar_tags = result["n"]
             results.append(obj)
         return results


### PR DESCRIPTION
This fixes the symptom, but not the cause. 

Since this entire method is deemed to be "a bit of a hack", and the issue has been open since 2011,--and is possibly cause by a Django issue--this seems like a sufficient solution.

I've successfully applied this patch in production (by extracting this method into a get_similar_objects function). The method will still return similar_objects, but no longer crashes on missing keys.

Ref: #80