### PR TITLE
Always evaluate .most_common() lazily

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,8 @@ UNRELEASED 1.0.0
  * Added multi-column unique constraint to model ``TaggedItem`` on fields
    ``content_type``, ``object_id``, and ``tag``. Databases that contain
    duplicates will need to add a data migration to resolve these duplicates.
+ * Fixed ``TaggableManager.most_common()`` to always evaluate lazily. Allows
+   placing a ``.most_common()`` query at the top level of a module.
 
 0.24.0 (2019-02-19)
 ~~~~~~~~~~~~~~~~~~~

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -142,10 +142,13 @@ class CommonGenericTaggedItemBase(ItemBase):
 
     @classmethod
     def tags_for(cls, model, instance=None, **extra_filters):
-        ct = ContentType.objects.get_for_model(model)
-        kwargs = {"%s__content_type" % cls.tag_relname(): ct}
+        tag_relname = cls.tag_relname()
+        kwargs = {
+            "%s__content_type__app_label" % tag_relname: model._meta.app_label,
+            "%s__content_type__model" % tag_relname: model._meta.model_name,
+        }
         if instance is not None:
-            kwargs["%s__object_id" % cls.tag_relname()] = instance.pk
+            kwargs["%s__object_id" % tag_relname] = instance.pk
         if extra_filters:
             kwargs.update(extra_filters)
         return cls.tag_model().objects.filter(**kwargs).distinct()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -143,6 +143,10 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
     taggeditem_model = TaggedItem
     tag_model = Tag
 
+    def setUp(self):
+        super().setUp()
+        ContentType.objects.clear_cache()
+
     def test_add_tag(self):
         apple = self.food_model.objects.create(name="apple")
         self.assertEqual(list(apple.tags.all()), [])
@@ -705,6 +709,12 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         self.taggeditem_model.objects.create(tag=tag, content_object=apple)
         with self.assertRaises(IntegrityError):
             self.taggeditem_model.objects.create(tag=tag, content_object=apple)
+
+    def test_most_common_lazy(self):
+        with self.assertNumQueries(0):
+            qs = self.food_model.tags.most_common()
+        with self.assertNumQueries(1):
+            list(qs)
 
 
 class TaggableManagerDirectTestCase(TaggableManagerTestCase):


### PR DESCRIPTION
Allows placing a .most_common() query at the top level of a module.

Fixes #532