### PR TITLE
modify contribute_to_class method,so it can use in abstract class

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -466,6 +466,25 @@ class TaggableManager(RelatedField):
         cls._meta.add_field(self)
         setattr(cls, name, self)
         if not cls._meta.abstract:
+            if self.remote_field.related_name:
+                related_name = self.remote_field.related_name
+            else:
+                related_name = self.opts.default_related_name
+            if related_name:
+                related_name = related_name % {
+                    'class': cls.__name__.lower(),
+                    'model_name': cls._meta.model_name.lower(),
+                    'app_label': cls._meta.app_label.lower()
+                }
+                self.remote_field.related_name = related_name
+
+            if self.remote_field.related_query_name:
+                related_query_name = self.remote_field.related_query_name % {
+                    'class': cls.__name__.lower(),
+                    'app_label': cls._meta.app_label.lower(),
+                }
+                self.remote_field.related_query_name = related_query_name
+
             if isinstance(self.remote_field.model, str):
 
                 def resolve_related_class(cls, model, field):

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -472,16 +472,16 @@ class TaggableManager(RelatedField):
                 related_name = self.opts.default_related_name
             if related_name:
                 related_name = related_name % {
-                    'class': cls.__name__.lower(),
-                    'model_name': cls._meta.model_name.lower(),
-                    'app_label': cls._meta.app_label.lower()
+                    "class": cls.__name__.lower(),
+                    "model_name": cls._meta.model_name.lower(),
+                    "app_label": cls._meta.app_label.lower(),
                 }
                 self.remote_field.related_name = related_name
 
             if self.remote_field.related_query_name:
                 related_query_name = self.remote_field.related_query_name % {
-                    'class': cls.__name__.lower(),
-                    'app_label': cls._meta.app_label.lower(),
+                    "class": cls.__name__.lower(),
+                    "app_label": cls._meta.app_label.lower(),
                 }
                 self.remote_field.related_query_name = related_query_name
 


### PR DESCRIPTION
I add tags field in a abstract model class, but where I  run makemigrations,it has some error about reverse related_name, so I used some code which in RelatedField's contribute_to_class method to resolve the error