### PR TITLE
Travis container based environment is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 cache: pip
 


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration