### PR TITLE
Remove support for end-of-life Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-django111
     - python: 3.5
-      env: TOXENV=py35-django20
-    - python: 3.6
-      env: TOXENV=py36-django20
-    - python: 3.7
-      env: TOXENV=py37-django20
-    - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ~~~~~~~~~~
 
 * Moved TaggedItemBase.tags_for() to ItemBase.
+* Removed support for end-of-life Django 2.0.
 
 1.1.0 (2019-03-22)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     flake8
     isort
     py{35,36,37}-django111
-    py{35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37}-django22
     py{36,37}-djangomaster
@@ -14,7 +13,6 @@ envlist =
 [testenv]
 deps =
     django111: Django~=1.11.0
-    django20: Django~=2.0.0
     django21: Django~=2.1.0
     django22: Django>=2.2<3.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz#egg=django


### PR DESCRIPTION
Will reduce testing time and resources.