### PR TITLE
Remove Unnecessary str() call

### DIFF
--- a/taggit/views.py
+++ b/taggit/views.py
@@ -10,7 +10,7 @@ def tagged_object_list(request, slug, queryset, **kwargs):
         queryset = queryset()
     kwargs["slug"] = slug
     tag_list_view = type(
-        str("TagListView"),
+        "TagListView",
         (TagListMixin, ListView),
         {"model": queryset.model, "queryset": queryset},
     )


### PR DESCRIPTION
Unnecessary since dropping support for Python 2 in
828e5481069d51a02ceb724bacbae371b8fdd1f0.