### PR TITLE
Replace .__class__ with type()

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -47,7 +47,7 @@ class ExtraJoinRestriction:
         self.alias = change_map.get(self.alias, self.alias)
 
     def clone(self):
-        return self.__class__(self.alias, self.col, self.content_types[:])
+        return type(self)(self.alias, self.col, self.content_types[:])
 
 
 class _TaggableManager(models.Manager):
@@ -73,7 +73,7 @@ class _TaggableManager(models.Manager):
             raise ValueError("Custom queryset can't be used for this lookup.")
 
         instance = instances[0]
-        db = self._db or router.db_for_read(instance.__class__, instance=instance)
+        db = self._db or router.db_for_read(type(instance), instance=instance)
 
         fieldname = (
             "object_id"

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -48,9 +48,9 @@ class TagBase(models.Model):
                 pass
             # Now try to find existing slugs with similar names
             slugs = set(
-                self.__class__._default_manager.filter(
-                    slug__startswith=self.slug
-                ).values_list("slug", flat=True)
+                type(self)
+                ._default_manager.filter(slug__startswith=self.slug)
+                .values_list("slug", flat=True)
             )
             i = 1
             while True:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -509,7 +509,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         food_instance = self.food_model()
         msg = (
             "%s objects need to have a primary key value before you can access "
-            "their tags." % self.food_model().__class__.__name__
+            "their tags." % type(self.food_model()).__name__
         )
         with self.assertRaisesMessage(ValueError, msg):
             food_instance.tags.all()
@@ -841,10 +841,10 @@ class TaggableManagerInitializationTestCase(TaggableManagerTestCase):
     custom_manager_model = CustomManager
 
     def test_default_manager(self):
-        self.assertEqual(self.food_model.tags.__class__, _TaggableManager)
+        self.assertIs(type(self.food_model.tags), _TaggableManager)
 
     def test_custom_manager(self):
-        self.assertEqual(self.custom_manager_model.tags.__class__, CustomManager.Foo)
+        self.assertIs(type(self.custom_manager_model.tags), CustomManager.Foo)
 
 
 class TaggableFormTestCase(BaseTaggingTestCase):


### PR DESCRIPTION
Using .__class__ was necessary to support Python 2 old style classes. In
Python 3, all classes are new style.