### PR TITLE
docs: Fix simple typo, oportunistic -> opportunistic

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -38,7 +38,7 @@ class TagBase(models.Model):
             # with a multi-master setup, theoretically we could try to
             # write and rollback on different DBs
             kwargs["using"] = using
-            # Be oportunistic and try to save the tag, this should work for
+            # Be opportunistic and try to save the tag, this should work for
             # most cases ;)
             try:
                 with transaction.atomic(using=using):


### PR DESCRIPTION
There is a small typo in taggit/models.py.

Should read `opportunistic` rather than `oportunistic`.

