### PR TITLE
Change case of verbose_name attributes to lowercase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+UNRELEASED
+~~~~~~~~~~
+
+* Model and field ``verbose_name`` and ``verbose_name_plural`` attributes are
+  now lowercase. This simplifies using the name in the middle of a sentence.
+  When used as a header, title, or at the beginning of a sentence, a text
+  transformed can be used to adjust the case.
+
 1.2.0 (2019-12-03)
 ~~~~~~~~~~~~~~~~~~
 

--- a/taggit/migrations/0001_initial.py
+++ b/taggit/migrations/0001_initial.py
@@ -22,17 +22,17 @@ class Migration(migrations.Migration):
                 (
                     "name",
                     models.CharField(
-                        help_text="", unique=True, max_length=100, verbose_name="Name"
+                        help_text="", unique=True, max_length=100, verbose_name="name"
                     ),
                 ),
                 (
                     "slug",
                     models.SlugField(
-                        help_text="", unique=True, max_length=100, verbose_name="Slug"
+                        help_text="", unique=True, max_length=100, verbose_name="slug"
                     ),
                 ),
             ],
-            options={"verbose_name": "Tag", "verbose_name_plural": "Tags"},
+            options={"verbose_name": "tag", "verbose_name_plural": "tags"},
             bases=(models.Model,),
         ),
         migrations.CreateModel(
@@ -51,14 +51,14 @@ class Migration(migrations.Migration):
                 (
                     "object_id",
                     models.IntegerField(
-                        help_text="", verbose_name="Object id", db_index=True
+                        help_text="", verbose_name="object ID", db_index=True
                     ),
                 ),
                 (
                     "content_type",
                     models.ForeignKey(
                         related_name="taggit_taggeditem_tagged_items",
-                        verbose_name="Content type",
+                        verbose_name="content type",
                         to="contenttypes.ContentType",
                         help_text="",
                         on_delete=models.CASCADE,
@@ -75,8 +75,8 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "Tagged Item",
-                "verbose_name_plural": "Tagged Items",
+                "verbose_name": "tagged item",
+                "verbose_name_plural": "tagged items",
             },
             bases=(models.Model,),
         ),

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -13,8 +13,8 @@ except ImportError:
 
 
 class TagBase(models.Model):
-    name = models.CharField(verbose_name=_("Name"), unique=True, max_length=100)
-    slug = models.SlugField(verbose_name=_("Slug"), unique=True, max_length=100)
+    name = models.CharField(verbose_name=_("name"), unique=True, max_length=100)
+    slug = models.SlugField(verbose_name=_("slug"), unique=True, max_length=100)
 
     def __str__(self):
         return self.name
@@ -73,8 +73,8 @@ class TagBase(models.Model):
 
 class Tag(TagBase):
     class Meta:
-        verbose_name = _("Tag")
-        verbose_name_plural = _("Tags")
+        verbose_name = _("tag")
+        verbose_name_plural = _("tags")
         app_label = "taggit"
 
 
@@ -125,7 +125,7 @@ class CommonGenericTaggedItemBase(ItemBase):
     content_type = models.ForeignKey(
         ContentType,
         on_delete=models.CASCADE,
-        verbose_name=_("Content type"),
+        verbose_name=_("content type"),
         related_name="%(app_label)s_%(class)s_tagged_items",
     )
     content_object = GenericForeignKey()
@@ -156,14 +156,14 @@ class CommonGenericTaggedItemBase(ItemBase):
 
 
 class GenericTaggedItemBase(CommonGenericTaggedItemBase):
-    object_id = models.IntegerField(verbose_name=_("Object id"), db_index=True)
+    object_id = models.IntegerField(verbose_name=_("object ID"), db_index=True)
 
     class Meta:
         abstract = True
 
 
 class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
-    object_id = models.UUIDField(verbose_name=_("Object id"), db_index=True)
+    object_id = models.UUIDField(verbose_name=_("object ID"), db_index=True)
 
     class Meta:
         abstract = True
@@ -171,8 +171,8 @@ class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
 
 class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
     class Meta:
-        verbose_name = _("Tagged Item")
-        verbose_name_plural = _("Tagged Items")
+        verbose_name = _("tagged item")
+        verbose_name_plural = _("tagged items")
         app_label = "taggit"
         index_together = [["content_type", "object_id"]]
         unique_together = [["content_type", "object_id", "tag"]]


### PR DESCRIPTION
Allows for using the name in a sentence. For uses that are a header,
title, or at the beginning of a sentence, a text transform can be used.