### PR TITLE
Prepare for the next release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,17 @@
 Changelog
 =========
 
-UNRELEASED
-~~~~~~~~~~
+1.3.0 (2020-05-19)
+~~~~~~~~~~~~~~~~~~
 
 * Model and field ``verbose_name`` and ``verbose_name_plural`` attributes are
   now lowercase. This simplifies using the name in the middle of a sentence.
   When used as a header, title, or at the beginning of a sentence, a text
   transformed can be used to adjust the case.
+* Fix prefetch_related when using UUIDTaggedItem.
+* Allow for passing in extra constructor parameters when using
+  ``TaggableManager.add``. This is especially useful when using custom
+  tag models.
 
 1.2.0 (2019-12-03)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@ project = "django-taggit"
 copyright = "Alex Gaynor and individual contributors."
 
 # The short X.Y version.
-version = "1.2"
+version = "1.3"
 # The full version, including alpha/beta/rc tags.
-release = "1.2.0"
+release = "1.3.0"
 
 intersphinx_mapping = {
     "django": (

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 2, 0)
+VERSION = (1, 3, 0)
 __version__ = ".".join(str(i) for i in VERSION)
 
 default_app_config = "taggit.apps.TaggitAppConfig"


### PR DESCRIPTION
I'm not sure who is the release manager for this lib, and I don't see any "autorelease on tag" infrastructure, so I'm going to ping both @auvipy and @jdufresne on this (apologies in advance to the one who didn't need to get pinged here)