### PR TITLE
Add tip for using custom models

### DIFF
--- a/docs/custom_tagging.rst
+++ b/docs/custom_tagging.rst
@@ -12,7 +12,9 @@ want to store additional data about a tag, such as whether it is official.  In
 these cases ``django-taggit`` makes it easy to substitute your own through
 model, or ``Tag`` model.
 
-Note: You will need to remove 'taggit' from `settings.py` if you do not want to create the default tables.
+Note: Including 'taggit' in ``settings.py`` will create the default ``django-taggit`` 
+and "through model" models. If you would like to use your own models, you will 
+need to remove 'taggit' from ``settings.py``.
 
 To change the behavior there are a number of classes you can subclass to obtain
 different behavior:

--- a/docs/custom_tagging.rst
+++ b/docs/custom_tagging.rst
@@ -14,7 +14,7 @@ model, or ``Tag`` model.
 
 Note: Including 'taggit' in ``settings.py`` will create the default ``django-taggit`` 
 and "through model" models. If you would like to use your own models, you will 
-need to remove 'taggit' from ``settings.py``.
+need to remove 'taggit' from ``settings.py``'s INSTALLED_APPS list.
 
 To change the behavior there are a number of classes you can subclass to obtain
 different behavior:

--- a/docs/custom_tagging.rst
+++ b/docs/custom_tagging.rst
@@ -12,6 +12,8 @@ want to store additional data about a tag, such as whether it is official.  In
 these cases ``django-taggit`` makes it easy to substitute your own through
 model, or ``Tag`` model.
 
+Note: You will need to remove 'taggit' from `settings.py` if you do not want to create the default tables.
+
 To change the behavior there are a number of classes you can subclass to obtain
 different behavior:
 

--- a/docs/custom_tagging.rst
+++ b/docs/custom_tagging.rst
@@ -12,9 +12,10 @@ want to store additional data about a tag, such as whether it is official.  In
 these cases ``django-taggit`` makes it easy to substitute your own through
 model, or ``Tag`` model.
 
-Note: Including 'taggit' in ``settings.py`` will create the default ``django-taggit`` 
-and "through model" models. If you would like to use your own models, you will 
-need to remove 'taggit' from ``settings.py``'s INSTALLED_APPS list.
+Note: Including 'taggit' in ``settings.py`` INSTALLED_APPS list will create the 
+default ``django-taggit`` and "through model" models. If you would like to use 
+your own models, you will need to remove 'taggit' from ``settings.py``'s 
+INSTALLED_APPS list.
 
 To change the behavior there are a number of classes you can subclass to obtain
 different behavior:


### PR DESCRIPTION
If you are using custom models, having 'taggit' in the installed apps will create database tables you do not need.