### PR TITLE
 Simplify isort config using 'profile = black'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,4 @@ exclude = tests*
 ignore = E501
 
 [isort]
-combine_as_imports = True
-forced_separate = taggit
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
+profile = black

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -2,7 +2,8 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, models, router, transaction
 from django.utils.text import slugify
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 
 try:
     from unidecode import unidecode

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,6 +7,11 @@ from django.db import IntegrityError, connection, models
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
+from taggit.managers import TaggableManager, _TaggableManager
+from taggit.models import Tag, TaggedItem
+from taggit.utils import edit_string_for_tags, parse_tags
+from taggit.views import tagged_object_list
+
 from .forms import (
     BlankTagForm,
     CustomPKFoodForm,
@@ -54,11 +59,6 @@ from .models import (
     UUIDTag,
     UUIDTaggedItem,
 )
-
-from taggit.managers import TaggableManager, _TaggableManager
-from taggit.models import Tag, TaggedItem
-from taggit.utils import edit_string_for_tags, parse_tags
-from taggit.views import tagged_object_list
 
 
 class BaseTaggingTestCase(TestCase):

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,8 +1,8 @@
 from django.views.generic.list import ListView
 
-from .models import Food
-
 from taggit.views import TagListMixin
+
+from .models import Food
 
 
 class FoodTagListView(TagListMixin, ListView):

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,8 @@ commands = flake8
 [testenv:isort]
 basepython = python3
 skip_install = true
-deps = isort
-commands = isort --recursive --check-only --diff
+deps = isort>=5.0.2
+commands = isort --check-only --diff .
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
isort now has builtin support for black through its "profiles" feature.

https://timothycrosley.github.io/isort/docs/configuration/profiles/#black