### PR TITLE
Allowing BigIntegerField in taggedItems

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -157,7 +157,7 @@ class CommonGenericTaggedItemBase(ItemBase):
 
 
 class GenericTaggedItemBase(CommonGenericTaggedItemBase):
-    object_id = models.IntegerField(verbose_name=_("object ID"), db_index=True)
+    object_id = models.BigIntegerField(verbose_name=_("object ID"), db_index=True)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Allows Taggable Items to have BigIntegerField as primary key. See https://github.com/jazzband/django-taggit/issues/692