### PR TITLE
Fixing issues on TOXENV=black as jobs not running on intel

### DIFF
--- a/tests/migrations/0002_auto_20200214_1129.py
+++ b/tests/migrations/0002_auto_20200214_1129.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
             options={"ordering": ["created_at"]},
         ),
         migrations.AlterModelOptions(
-            name="uuidfood", options={"ordering": ["created_at"]},
+            name="uuidfood", options={"ordering": ["created_at"]}
         ),
         migrations.AddField(
             model_name="blanktagmodel",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -126,14 +126,10 @@ class CustomTagCreationTestCase(TestCase):
         apple = OfficialFood.objects.create(name="apple")
 
         # let's add two official tags
-        apple.tags.add(
-            "foo", "bar", tag_kwargs={"official": True},
-        )
+        apple.tags.add("foo", "bar", tag_kwargs={"official": True})
 
         # and two unofficial ones
-        apple.tags.add(
-            "baz", "wow", tag_kwargs={"official": False},
-        )
+        apple.tags.add("baz", "wow", tag_kwargs={"official": False})
 
         # We should end up with 4 tags
         self.assertEquals(apple.tags.count(), 4)


### PR DESCRIPTION
Hi,
While running jobs on travis-ci, I encountered that jobs on TOXENV=black were failing. I looked into it and came up with the possible fix. It appears the fix is ready to review and merge, so kindly have a look to it.
Jobs can be verified by: https://travis-ci.com/github/kishorkunal-raj/django-taggit/builds/190199247

Thanks!
Regards 
Kishor Kunal Raj