### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
   - 3.7
   - 3.8
 
+arch:
+  - ppc64le
+  - amd64
+
 jobs:
   fast_finish: true
   include:
@@ -17,6 +21,19 @@ jobs:
     - python: 3.8
       env: TOXENV=isort
     - python: 3.8
+      env: TOXENV=docs
+      #Adding jobs for ppc64le architecture
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=black
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=flake8
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=isort
+    - python: 3.8
+      arch: ppc64le
       env: TOXENV=docs
 
     - stage: deploy
@@ -35,6 +52,9 @@ jobs:
           repo: jazzband/django-taggit
 install:
   - pip install tox-travis codecov
+
+before_script:
+  - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then  sudo chown -R $USER:$GROUP ~/.cache/pip/wheels; fi
 
 script:
 - tox


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-taggit/builds/190231738

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj