### PR TITLE
Add default_auto_field to TaggitAppConfig

### DIFF
--- a/taggit/apps.py
+++ b/taggit/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class TaggitAppConfig(BaseConfig):
     name = "taggit"
     verbose_name = _("Taggit")
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Django 3.2 [introduces](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys) a change that wants `default_auto_field` to be set on an AppConfig, or else the `DEFAULT_AUTO_FIELD` setting set. Otherwise a warning is generated.

Added the setting to `TaggitAppConfig` in order to keep the existing behaviour.

Fixes #717