### PR TITLE
Some slight documentation tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,5 +53,5 @@ Tags will show up for you automatically in forms and the admin.
 
 For more info check out the `documentation
 <https://django-taggit.readthedocs.io/>`_. And for questions about usage or
-development you can contact the `mailinglist
-<https://groups.google.com/group/django-taggit>`_.
+development you can create an issue on Github (if your question is about
+usage please add the `question` tag).

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,11 @@
+Frequently Asked Questions
+==========================
+
+
+- How can I use this with factory_boy?
+
+ Since these are all built off of many-to-many relationships, you can check out `factory_boy's documentation on this topic<https://factoryboy.readthedocs.io/en/stable/recipes.html#simple-many-to-many-relationship>`_ and get some ideas on how to deal with tags.
+
+- How can I use this with Django Rest Framework?
+
+ `django-taggit-serializer<https://github.com/glemmaPaul/django-taggit-serializer>`_ offers support for working with tags and DRF together.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ tagging to your project easy and fun.
    forms
    admin
    api
+   faq
    custom_tagging
    contributing
    external_apps


### PR DESCRIPTION
This removes the (basically unused) mailinlist form the readme, instead pointing people to open up a GH issue.

I also add an FAQ page for the docs, though for now I only have two simple questions answered.