### PR TITLE
Bump the taggit version number to 1.4.0

### DIFF
--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 4, 0)
 __version__ = ".".join(str(i) for i in VERSION)
 
 default_app_config = "taggit.apps.TaggitAppConfig"


### PR DESCRIPTION
 I missed this step when preparing the release, causing the release step to fail upon tagging. 