### PR TITLE
Update black target to Python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ ignore_errors =
 basepython = python3
 skip_install = true
 deps = black
-commands = black --target-version=py35 --check --diff .
+commands = black --target-version=py36 --check --diff .
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
Python 3.5 is no longer supported. Refs 7cea0b2d7af23d7c0e04f52d60abf3dd175cb26d