### PR TITLE
Update faq.rst

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -4,8 +4,8 @@ Frequently Asked Questions
 
 - How can I use this with factory_boy?
 
- Since these are all built off of many-to-many relationships, you can check out `factory_boy's documentation on this topic<https://factoryboy.readthedocs.io/en/stable/recipes.html#simple-many-to-many-relationship>`_ and get some ideas on how to deal with tags.
+ Since these are all built off of many-to-many relationships, you can check out `factory_boy's documentation on this topic <https://factoryboy.readthedocs.io/en/stable/recipes.html#simple-many-to-many-relationship>`_ and get some ideas on how to deal with tags.
 
 - How can I use this with Django Rest Framework?
 
- `django-taggit-serializer<https://github.com/glemmaPaul/django-taggit-serializer>`_ offers support for working with tags and DRF together.
+ `django-taggit-serializer <https://github.com/glemmaPaul/django-taggit-serializer>`_ offers support for working with tags and DRF together.


### PR DESCRIPTION
Add single space between text string and URL to fix broken link display on readthedocs.io