### PR TITLE
Prepare Release 1.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,15 @@ Changelog
 
 * (nothing here yet)
 
+1.5.1 (2021-07-01)
+~~~~~~~~~~~~~~~~~~
 
-1.5.0 (2021-05-30)
+* Fix compiled Ukranian translation (which would cause a failure on load for this locale).
+* Update compiled Danish translation.
+
+
+
+1.5.0 (2021-06-30)
 ~~~~~~~~~~~~~~~~~~
 
 * Vendor in the `django-taggit-serializer` project (under `taggit.serializers`).

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -4,7 +4,7 @@ except ImportError:
     # setup.py and docs do not have Django installed.
     django = None
 
-VERSION = (1, 5, 0)
+VERSION = (1, 5, 1)
 __version__ = ".".join(str(i) for i in VERSION)
 
 if django and django.VERSION < (3, 2):


### PR DESCRIPTION
 This is a bit of a bugfix release to get the most recent version of the library in a working state again. (This also fixes a mistaken timestamp in the changelog)