### PR TITLE
Fix TagField.has_changed for empty values 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Fix issue where ``TagField`` would incorrectly report that a field has changed on empty values.
 * Update Russian translation.
 * Provide translators additional context regarding strings in TagBase model.
 

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -49,3 +49,5 @@ form with normal many to many fields on it::
             obj.save()
             # Without this next line the tags won't be saved.
             form.save_m2m()
+
+You can check the details over in the `Django documentation on form saving <https://docs.djangoproject.com/en/3.2/topics/forms/modelforms/#the-save-method>`_.

--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -42,7 +42,10 @@ class TagField(forms.CharField):
         except forms.ValidationError:
             pass
 
-        if initial_value is None:
+        # normalize "empty values"
+        if not data_value:
+            data_value = []
+        if not initial_value:
             initial_value = []
 
         initial_value = [tag.name for tag in initial_value]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -52,3 +52,11 @@ class TagFieldTests(TestCase):
         )
 
         self.assertFalse(form.has_changed())
+
+    def test_should_return_False_if_not_provided(self):
+        class TestForm(forms.Form):
+            tag = TagField()
+
+        form = TestForm()
+
+        self.assertFalse(form.has_changed())


### PR DESCRIPTION
Thanks to #749  for the initial report and pointing to a potential fix.

Also tries to address #752 by adding a link to Django docs.
