### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+2.0.0 (2021-11-14)
+~~~~~~~~~~~~~~~~~~
+
 * **Backwards incompatible:** ``TaggableManager.set`` now takes a list of tags
   (instead of varargs) so that its API matches Django's ``RelatedManager.set``. Example:
 

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -4,7 +4,7 @@ except ImportError:
     # setup.py and docs do not have Django installed.
     django = None
 
-VERSION = (1, 5, 1)
+VERSION = (2, 0, 0)
 __version__ = ".".join(str(i) for i in VERSION)
 
 if django and django.VERSION < (3, 2):


### PR DESCRIPTION
 This is version 2.0.0 because of an API compatibility change.