### PR TITLE
Fix doc build and workflow job name.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Python ${{ matrix.python }}
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
 
     # The maximum number of minutes to let a workflow run

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,1 +1,2 @@
 Sphinx
+docutils<0.18


### PR DESCRIPTION
I've noticed that the documentation build was broken after looking into the 2.0.0 release and found it to be related to https://github.com/sphinx-doc/sphinx/issues/9811, one of the many incarnations of docutils 0.18 containing breaking changes for Sphinx. This pins to docutils<0.18 to work around it for now.

I've also took the liberty to enable [pull request building for the docs via Read The Docs](https://docs.readthedocs.io/en/stable/pull-requests.html), so we see build issues earlier, see the pull request jobs/checks below. The preview is here: https://django-taggit--768.org.readthedocs.build/en/768/

