### PR TITLE
Add Django 4.0 to testing environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     isort
     py{36,37,38,39}-dj{22,31}
     py{36,37,38,39,310}-dj32
+    py{38,39,310}-dj40
     py{38,39,310}-djmain
     docs
 
@@ -22,6 +23,7 @@ deps =
     dj22: Django>=2.2,<3.0
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     djangorestframework


### PR DESCRIPTION
Just adds Django 4.0 to the ci

Currently fails due to (at least) #776.