### PR TITLE
Fix Django 4 compatibility issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~
 
 * Add Python 3.10 support.
+* Add Django 4.0 support.
 
 2.0.0 (2021-11-14)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Framework :: Django :: 2.2
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -1,6 +1,7 @@
 import uuid
 from operator import attrgetter
 
+import django
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -666,13 +667,25 @@ class TaggableManager(RelatedField):
         else:
             return (("object_id", self.model._meta.pk.column),)
 
-    def get_extra_restriction(self, where_class, alias, related_alias):
+    def _get_extra_restriction(self, alias, related_alias):
         extra_col = self.through._meta.get_field("content_type").column
         content_type_ids = [
             ContentType.objects.get_for_model(subclass).pk
             for subclass in _get_subclasses(self.model)
         ]
         return ExtraJoinRestriction(related_alias, extra_col, content_type_ids)
+
+    def _get_extra_restriction_legacy(self, where_class, alias, related_alias):
+        # this is a shim to maintain compatibility with django < 4.0
+        return self._get_extra_restriction(alias, related_alias)
+
+    # this is required to handle a change in Django 4.0
+    # https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
+    # the signature of the (private) funtion was changed
+    if django.VERSION > (3, 8):
+        get_extra_restriction = _get_extra_restriction
+    else:
+        get_extra_restriction = _get_extra_restriction_legacy
 
     def get_reverse_joining_columns(self):
         return self.get_joining_columns(reverse_join=True)

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -682,10 +682,10 @@ class TaggableManager(RelatedField):
     # this is required to handle a change in Django 4.0
     # https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
     # the signature of the (private) funtion was changed
-    if django.VERSION > (3, 8):
-        get_extra_restriction = _get_extra_restriction
-    else:
+    if django.VERSION < (4, 0):
         get_extra_restriction = _get_extra_restriction_legacy
+    else:
+        get_extra_restriction = _get_extra_restriction
 
     def get_reverse_joining_columns(self):
         return self.get_joining_columns(reverse_join=True)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     isort
     py{36,37,38,39}-dj{22,31}
     py{36,37,38,39,310}-dj32
+    py{38,39,310}-dj40
     py{38,39,310}-djmain
     docs
 
@@ -22,6 +23,7 @@ deps =
     dj22: Django>=2.2,<3.0
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     djangorestframework


### PR DESCRIPTION
The `where_class` argument to the private `get_extra_restriction()` was [changed](https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous) in Django 4.0.

A simple change is to remove the `where_class` argument [here](https://github.com/jazzband/django-taggit/blob/4042b8562d72b8b65581de01277e8b37514cf514/taggit/managers.py#L669). But that breaks taggit on lower versions of django.

To fix this, I added a shim that checks the django version and uses the correct function. 
I have no idea if this is the best way to fix this, but the tests pass 🤷‍♂️ 

Relevant issue: #776 

Note that this PR has a commit from #777 too.