### PR TITLE
Update django

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Add Python 3.10 support.
 * Add Django 4.0 support.
+* Drop Django 3.1 support.
 
 2.0.0 (2021-11-14)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Intended Audience :: Developers

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -41,7 +41,7 @@ class ExtraJoinRestriction:
     def as_sql(self, compiler, connection):
         qn = compiler.quote_name_unless_alias
         if len(self.content_types) == 1:
-            extra_where = "{}.{} = %s".format(qn(self.alias), qn(self.col))
+            extra_where = f"{qn(self.alias)}.{qn(self.col)} = %s"
         else:
             extra_where = "{}.{} IN ({})".format(
                 qn(self.alias), qn(self.col), ",".join(["%s"] * len(self.content_types))
@@ -228,7 +228,7 @@ class _TaggableManager(models.Manager):
             # do a query.  Malcolm is very smart.
             existing = manager.filter(name__in=str_tags, **tag_kwargs)
 
-            tags_to_create = str_tags - set(t.name for t in existing)
+            tags_to_create = str_tags - {t.name for t in existing}
 
         tag_objs.update(existing)
 

--- a/taggit/serializers.py
+++ b/taggit/serializers.py
@@ -54,7 +54,7 @@ class TagListSerializerField(serializers.Field):
         kwargs["style"] = {"base_template": "textarea.html"}
         kwargs["style"].update(style)
 
-        super(TagListSerializerField, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.pretty_print = pretty_print
 
@@ -95,14 +95,14 @@ class TaggitSerializer(serializers.Serializer):
     def create(self, validated_data):
         to_be_tagged, validated_data = self._pop_tags(validated_data)
 
-        tag_object = super(TaggitSerializer, self).create(validated_data)
+        tag_object = super().create(validated_data)
 
         return self._save_tags(tag_object, to_be_tagged)
 
     def update(self, instance, validated_data):
         to_be_tagged, validated_data = self._pop_tags(validated_data)
 
-        tag_object = super(TaggitSerializer, self).update(instance, validated_data)
+        tag_object = super().update(instance, validated_data)
 
         return self._save_tags(tag_object, to_be_tagged)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -588,7 +588,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         model_name = self.pet_model.__name__
         self.assertQuerysetEqual(
             pks,
-            ["<{}: kitty>".format(model_name), "<{}: cat>".format(model_name)],
+            [f"<{model_name}: kitty>", f"<{model_name}: cat>"],
             ordered=False,
         )
 
@@ -605,7 +605,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         model_name = self.food_model.__name__
         self.assertQuerysetEqual(
             pks,
-            ["<{}: pear>".format(model_name), "<{}: guava>".format(model_name)],
+            [f"<{model_name}: pear>", f"<{model_name}: guava>"],
             ordered=False,
         )
 
@@ -1234,7 +1234,7 @@ class TagListViewTests(TestCase):
         self.strawberry.tags.add("red")
 
     def test_url_request_returns_view(self):
-        request = self.factory.get("/food/tags/{}/".format(self.slug))
+        request = self.factory.get(f"/food/tags/{self.slug}/")
         queryset = self.model.objects.all()
         response = tagged_object_list(request, self.slug, queryset)
         self.assertEqual(response.status_code, 200)
@@ -1245,7 +1245,7 @@ class TagListViewTests(TestCase):
         )
 
     def test_list_view_returns_single(self):
-        response = self.client.get("/food/tags/{}/".format(self.slug))
+        response = self.client.get(f"/food/tags/{self.slug}/")
         self.assertEqual(response.status_code, 200)
         self.assertIn(self.apple, response.context_data["object_list"])
         self.assertNotIn(self.strawberry, response.context_data["object_list"])

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,9 @@ envlist =
     black
     flake8
     isort
-    py{36,37,38,39}-dj{22,31}
+    py{36,37,38,39}-dj22
     py{36,37,38,39,310}-dj32
-    py{38,39,310}-dj40
-    py{38,39,310}-djmain
+    py{38,39,310}-dj{40,main}
     docs
 
 [gh-actions]
@@ -21,7 +20,6 @@ python =
 [testenv]
 deps =
     dj22: Django>=2.2,<3.0
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Django 4.0 is out and it's time to drop support for all versions older than the most recent LTS.
