### PR TITLE
Set transform=repr on assertQuerysetEqual (Dj4.1 compatibility)

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -592,6 +592,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             pks,
             [f"<{model_name}: kitty>", f"<{model_name}: cat>"],
             ordered=False,
+            transform=repr,
         )
 
     def test_exclude(self):
@@ -609,6 +610,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             pks,
             [f"<{model_name}: pear>", f"<{model_name}: guava>"],
             ordered=False,
+            transform=repr,
         )
 
     def test_multi_inheritance_similarity_by_tag(self):


### PR DESCRIPTION
The old behaviour of assertQuerysetEqual automatically calling repr is deprecated in Django 3.2 https://docs.djangoproject.com/en/4.0/releases/3.2/#id3 and dropped in Django 4.1.