### PR TITLE
Handle path_infos / reverse_path_infos cached properties (Dj4.1 compatibility)

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -14,6 +14,7 @@ from django.db.models.fields.related import (
     lazy_related_operation,
 )
 from django.db.models.query_utils import PathInfo
+from django.utils.functional import cached_property
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
@@ -651,6 +652,10 @@ class TaggableManager(RelatedField):
                 direct=True, filtered_relation=filtered_relation
             )
 
+    @cached_property
+    def path_infos(self):
+        return self.get_path_info()
+
     def get_reverse_path_info(self, filtered_relation=None):
         if self.use_gfk:
             return self._get_gfk_case_path_info(
@@ -660,6 +665,10 @@ class TaggableManager(RelatedField):
             return self._get_mm_case_path_info(
                 direct=False, filtered_relation=filtered_relation
             )
+
+    @cached_property
+    def reverse_path_infos(self):
+        return self.get_reverse_path_info()
 
     def get_joining_columns(self, reverse_join=False):
         if reverse_join:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -592,6 +592,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             pks,
             [f"<{model_name}: kitty>", f"<{model_name}: cat>"],
             ordered=False,
+            transform=repr,
         )
 
     def test_exclude(self):
@@ -609,6 +610,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             pks,
             [f"<{model_name}: pear>", f"<{model_name}: guava>"],
             ordered=False,
+            transform=repr,
         )
 
     def test_multi_inheritance_similarity_by_tag(self):


### PR DESCRIPTION
In https://github.com/django/django/commit/a697424969f7f464bf6492b09a6cdac135499e02 / https://github.com/django/django/pull/14750, Django has introduced two new cached properties `path_infos` and `reverse_path_infos` to be used in preference to the `get_path_info()` and `get_reverse_path_info()` methods when not passing a `filtered_relation` argument.

TaggableManager is patching these methods, so to avoid Django bypassing them (specifically in `django.db.query.Query.names_to_path`) it needs to provide these cached properties too.

For additional bonus points, we also update TaggableManager's `_get_mm_case_path_info` and `_get_gfk_case_path_info` methods to make use of the new cached properties where available.

This (along with #791, incorporated here) gets the test suite passing again on the current Django main branch.