### PR TITLE
Docs: replace deprecated/removed `django.utils.translation.ugettext_lazy`

### DIFF
--- a/docs/custom_tagging.rst
+++ b/docs/custom_tagging.rst
@@ -93,7 +93,7 @@ to use with models using an UUID primary key:
   .. code-block:: python
 
     from django.db import models
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     from taggit.managers import TaggableManager
     from taggit.models import GenericUUIDTaggedItemBase, TaggedItemBase
@@ -122,7 +122,7 @@ model named ``"tag"``. If your custom ``Tag`` model has extra parameters you wan
   .. code-block:: python
 
     from django.db import models
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     from taggit.managers import TaggableManager
     from taggit.models import TagBase, GenericTaggedItemBase


### PR DESCRIPTION
`django.utils.translation.ugettext_lazy` was deprecated in Django 3.0 and removed in Django 4.0 in favor of `django.utils.translation.gettext_lazy`.