### PR TITLE
Version bump to 3.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-(Unreleased)
-~~~~~~~~~~~~
+3.0.0 (Unreleased)
+~~~~~~~~~~~~~~~~~~
 
 * **Backwards incompatible:** Tag slugification used to silently strip non-ASCII characters
   from the tag name to make the slug. This leads to a lot of confusion for anyone using

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -4,7 +4,7 @@ except ImportError:
     # setup.py and docs do not have Django installed.
     django = None
 
-VERSION = (2, 1, 0)
+VERSION = (3, 0, 0)
 __version__ = ".".join(str(i) for i in VERSION)
 
 if django and django.VERSION < (3, 2):


### PR DESCRIPTION
Hopefully not controversial (#797 is an upcoming breaking change, and django-taggit has followed semver in previous cases like this) but if you're curious why I'm proposing this right now: we're [testing Wagtail against Django git main](https://github.com/wagtail/wagtail/blob/8efb235695887ca6b0388f7f5640452ee92a2c22/.github/workflows/test.yml#L82-L85), which necessitates also installing django-taggit git master for the 4.1 fixes (#791, #792). Our test suite includes a check for missing migrations, and currently that's being triggered by the `allow_unicode` change in #797. Bumping the version now will allow us to hack a version check into our migrations and keep them working against both the current release version and git master.