### PR TITLE
Clear prefetch cache on tag updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Fixed an issue where object caches would not be properly cleared after updating tags, leading
+  to stale reads in cases where `prefetch_related` is used.
+
 3.0.0 (2022-05-02)
 ~~~~~~~~~~~~~~~~~~
 

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -143,10 +143,9 @@ class _TaggableManager(models.Manager):
         return self.through.lookup_kwargs(self.instance)
 
     def _remove_prefetched_objects(self):
-        try:
-            self.instance._prefetched_objects_cache.pop(self.prefetch_cache_name)
-        except (AttributeError, KeyError):
-            pass  # nothing to clear from cache
+        prefetch_cache = getattr(self.instance, "_prefetched_objects_cache", None)
+        if prefetch_cache:
+            prefetch_cache.pop(self.prefetch_cache_name, None)
 
     @require_instance_manager
     def add(self, *tags, through_defaults=None, tag_kwargs=None, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,3 +25,39 @@ class TestSlugification(TestCase):
             # unicode-ness will be kept by default
             sample_obj.tags.add("あい うえお")
             self.assertEqual([tag.slug for tag in sample_obj.tags.all()], [""])
+
+
+class TestPrefetchCache(TestCase):
+    def setUp(self) -> None:
+        sample_obj = TestModel.objects.create()
+        sample_obj.tags.set(["1", "2", "3"])
+
+    def test_cache_clears_on_add(self):
+        """
+        Test that the prefetch cache gets cleared on tag addition
+        """
+        sample_obj = TestModel.objects.prefetch_related("tags").get()
+        self.assertTrue(sample_obj.tags.is_cached(sample_obj))
+
+        sample_obj.tags.add("4")
+        self.assertFalse(sample_obj.tags.is_cached(sample_obj))
+
+    def test_cache_clears_on_remove(self):
+        """
+        Test that the prefetch cache gets cleared on tag removal
+        """
+        sample_obj = TestModel.objects.prefetch_related("tags").get()
+        self.assertTrue(sample_obj.tags.is_cached(sample_obj))
+
+        sample_obj.tags.remove("3")
+        self.assertFalse(sample_obj.tags.is_cached(sample_obj))
+
+    def test_cache_clears_on_clear(self):
+        """
+        Test that the prefetch cache gets cleared when tags are cleared
+        """
+        sample_obj = TestModel.objects.prefetch_related("tags").get()
+        self.assertTrue(sample_obj.tags.is_cached(sample_obj))
+
+        sample_obj.tags.clear()
+        self.assertFalse(sample_obj.tags.is_cached(sample_obj))

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,8 +5,7 @@ test_django-taggit-serializer
 Tests for `django-taggit-serializer` models module.
 """
 
-import unittest
-
+from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 
 from taggit import serializers
@@ -15,7 +14,7 @@ from .models import TestModel
 from .serializers import TestModelSerializer
 
 
-class TestTaggit_serializer(unittest.TestCase):
+class TestTaggit_serializer(TestCase):
     def test_taggit_serializer_field(self):
         correct_value = ["1", "2", "3"]
         serializer_field = serializers.TagListSerializerField()
@@ -87,8 +86,4 @@ class TestTaggit_serializer(unittest.TestCase):
         serializer.is_valid()
         test_model = serializer.save()
 
-        assert len(test_model.tags.all()) == len(request_data["tags"])
         assert set(serializer.data["tags"]) == set(request_data["tags"])
-        assert TestModel.objects.filter(tags__name="1").exists() is False
-        assert TestModel.objects.filter(tags__name="2").exists() is True
-        assert TestModel.objects.filter(tags__name="3").exists() is True

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -74,16 +74,17 @@ class TestTaggit_serializer(TestCase):
 
     def test_returns_new_data_after_update(self):
         """
-        Test if the the prefetch cache clears after an updates
+        Test if the serializer uses fresh data after updating prefetched fields
         """
         TestModel.objects.create().tags.add("1")
 
         test_model = TestModel.objects.prefetch_related("tags").get()
 
-        request_data = {"tags": ["2", "3"]}
+        assert TestModelSerializer(test_model).data["tags"] == ["1"]
 
+        request_data = {"tags": ["2", "3"]}
         serializer = TestModelSerializer(test_model, data=request_data)
         serializer.is_valid()
         test_model = serializer.save()
 
-        assert set(serializer.data["tags"]) == set(request_data["tags"])
+        assert set(serializer.data["tags"]) == {"2", "3"}


### PR DESCRIPTION
This mimics the behaviour of Django's `ManyRelatedManager`

Take `test_returns_new_data_after_update`. It emulates the behaviour of Django-rest-framework's UpdateModelMixin.

If I did any `prefetch_related` on my QuerySet, the resulting data still uses the prefetched results instead of the updated data.