### PR TITLE
Fix settings list markup in the getting started docs.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -38,7 +38,7 @@ The following Django-level settings affect the behavior of the library
 
   When set to ``True``, tag lookups will be case insensitive. This defaults to ``False``.
 
-`` ``TAGGIT_STRIP_UNICODE_WHEN_SLUGIFYING``
+* ``TAGGIT_STRIP_UNICODE_WHEN_SLUGIFYING``
   When this is set to ``True``, tag slugs will be limited to ASCII characters. In this case, if you also have ```unidecode`` installed,
   then tag sluggification will transform a tag like ``あい　うえお`` to ``ai-ueo``.
   If you do not have ``unidecode`` installed, then you will usually be outright stripping unicode, meaning that something like ``helloあい`` will be slugified as ``hello``.


### PR DESCRIPTION
Right now settings list looks incorrect and the PR fixes that:

<img width="706" alt="Знімок екрана 2022-07-21 о 14 21 38" src="https://user-images.githubusercontent.com/673711/180202013-36c98d26-a12e-4747-87e2-996eac28d75e.png">
