### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -3,7 +3,7 @@ Frequently Asked Questions
 
 - How can I get all my tags?
 
- If you are using just an out-of-the-box setup, your tags are storred in the `Tag` model (found in `taggit.models`). If this is a custom model (for example you have your own models derived from `ItemBase`), then you'll need to query that one instead.
+ If you are using just an out-of-the-box setup, your tags are stored in the `Tag` model (found in `taggit.models`). If this is a custom model (for example you have your own models derived from `ItemBase`), then you'll need to query that one instead.
 
  So if you are using the standard setup, ``Tag.objects.all()`` will give you the tags.
 

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -720,7 +720,7 @@ class TaggableManager(RelatedField):
 
     # this is required to handle a change in Django 4.0
     # https://docs.djangoproject.com/en/4.0/releases/4.0/#miscellaneous
-    # the signature of the (private) funtion was changed
+    # the signature of the (private) function was changed
     if django.VERSION < (4, 0):
         get_extra_restriction = _get_extra_restriction_legacy
     else:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -520,7 +520,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         pear = self.food_model.objects.create(name="pear")
         #   1 query to see which tags exist
         #   1  query to check existing ids for sending m2m_changed signal
-        # + 4 queries to create the intermeidary things (including SELECTs, to
+        # + 4 queries to create the intermediary things (including SELECTs, to
         #     make sure we dont't double create.
         # + 4 for save points.
         queries = 10


### PR DESCRIPTION
There are small typos in:
- docs/faq.rst
- taggit/managers.py
- tests/tests.py

Fixes:
- Should read `stored` rather than `storred`.
- Should read `intermediary` rather than `intermeidary`.
- Should read `function` rather than `funtion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md