### PR TITLE
Update TagListSerializerField to ListField subclass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
   to stale reads in cases where `prefetch_related` is used.
 * Add Python 3.11 support.
 * Add Django 4.1 support.
+* Fixed an issue where TagListSerializerField caused the tags field to show a string.
 
 3.0.0 (2022-05-02)
 ~~~~~~~~~~~~~~~~~~

--- a/taggit/serializers.py
+++ b/taggit/serializers.py
@@ -33,7 +33,7 @@ class TagList(list):
             return json.dumps(self)
 
 
-class TagListSerializerField(serializers.Field):
+class TagListSerializerField(serializers.ListField):
     child = serializers.CharField()
     default_error_messages = {
         "not_a_list": gettext_lazy(


### PR DESCRIPTION
# Description
This pull request is to resolve an issue with the current serializer. When using drf_yasg or other api documentation tools, the tags filed shows as a string instead of a list. This Pull request will update `TagListSerializerField` to properly inherit from the `ListField` class. 

Closes: #828 