### PR TITLE
Make TagListSerializerField subclass ListField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,10 @@ Changelog
 ~~~~~~~~~~~~
 
 * Fixed an issue where object caches would not be properly cleared after updating tags, leading
-  to stale reads in cases where `prefetch_related` is used.
+  to stale reads in cases where ``prefetch_related`` is used.
 * Add Python 3.11 support.
 * Add Django 4.1 support.
+* Change ``TagListSerializerField`` to be a subclass of ``ListField``. This should improve support for API document generation. This change should not affect API behavior, but might affect metaprogramming code, so please procede carefully during this update.
 
 3.0.0 (2022-05-02)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,10 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Add Python 3.11 support (no code changes were needed, but now we test this release).
+* Add Django 4.1 support (no code changes were needed, but now we test this release).
 * Fixed an issue where object caches would not be properly cleared after updating tags, leading
   to stale reads in cases where ``prefetch_related`` is used.
-* Add Python 3.11 support.
-* Add Django 4.1 support.
 * Change ``TagListSerializerField`` to be a subclass of ``ListField``. This should improve support for API document generation. This change should not affect API behavior, but might affect metaprogramming code, so please procede carefully during this update.
 
 3.0.0 (2022-05-02)

--- a/taggit/serializers.py
+++ b/taggit/serializers.py
@@ -11,6 +11,11 @@ from rest_framework import serializers
 
 
 class TagList(list):
+    """
+    This tag list subclass adds pretty printing support to the tag list
+    serializer
+    """
+
     def __init__(self, *args, **kwargs):
         pretty_print = kwargs.pop("pretty_print", True)
         super().__init__(*args, **kwargs)
@@ -33,7 +38,15 @@ class TagList(list):
             return json.dumps(self)
 
 
-class TagListSerializerField(serializers.Field):
+class TagListSerializerField(serializers.ListField):
+    """
+    A serializer field that can write out a tag list
+
+    This serializer field has some odd qualities compared to just using a ListField.
+    If this field poses problems, we should introduce a new field that is a simpler
+    ListField implementation with less features.
+    """
+
     child = serializers.CharField()
     default_error_messages = {
         "not_a_list": gettext_lazy(
@@ -59,6 +72,11 @@ class TagListSerializerField(serializers.Field):
         self.pretty_print = pretty_print
 
     def to_internal_value(self, value):
+        # note to future maintainers: this field used to not be a ListField
+        # and has extra behavior to support string-based input.
+        #
+        # In the future we should look at removing this feature so we can
+        # make this a simple ListField (if feasible)
         if isinstance(value, str):
             if not value:
                 value = "[]"

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -51,10 +51,23 @@ class TestTaggit_serializer(TestCase):
         request_data = {"tags": ["1", "2", "3"]}
 
         serializer = TestModelSerializer(data=request_data)
-        serializer.is_valid()
+        assert serializer.is_valid()
         test_model = serializer.save()
 
         assert len(test_model.tags.all()) == len(request_data.get("tags"))
+
+    def test_taggit_serializer_create_with_string(self):
+        """
+        Test that we can pass in a string instead of an array for
+        a tag list without issues
+        """
+        request_data = {"tags": '["1", "2", "3"]'}
+
+        serializer = TestModelSerializer(data=request_data)
+        assert serializer.is_valid(), serializer.errors
+        test_model = serializer.save()
+
+        assert set(tag.name for tag in test_model.tags.all()) == {"1", "2", "3"}
 
     def test_taggit_removes_tags(self):
         """


### PR DESCRIPTION
This is a very tricky change, and I expect some issues once people begin using this in earnest. But it is closer to where we want to be, and the main functionality is being tested. 

This change is motivated by documentation tools not properly identifying this field as a `ListField`.

This also includes ome documentation tweaks in the changelog

Thanks to @brittandeyoung for the initial PR

Fixes #828
