### PR TITLE
Update GH Actions and tox.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # The maximum number of minutes to let a workflow run
     # before GitHub automatically cancels it. Default: 360
@@ -28,7 +28,7 @@ jobs:
           - '3.11'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+Update github workflows test.yaml and tox(no code changes were needed).
+
+* Workaround for python versioning in ubuntu, see ``issue #846`` for more info.
+* Update checkout to ``actions/checkout@v3`` to silence depracation warnings.
+
+Update tox (no code changes were needed).
+* Update ``Django`` test matrix, ``dj-main`` min version now ``py3.10``.
+
 3.1.0 (2022-11-08)
 ~~~~~~~~~~~~~~~~~~
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     isort
     py{36,37,38,39,310}-dj32
     py{38,39,310}-dj40
-    py{38,39,310,311}-dj{41,main}
+    py{38,39,310,311}-dj41
+    py{310,311}-dj{main}
     docs
 
 [gh-actions]


### PR DESCRIPTION
GitHub tests  workflow.

* Add a workaround for tests to pass, see issue #846 for info and  a link to GH issue/discussion.  Users have pinned to Ubuntu 20.04 until a solution is found. 

* Update actions/checkout@v2 to actions/checkout@v3 to silence deprecation warnings.

Tox Django test matrix.

* Updated dj-main to minimum py3.10.

closes #846 