### PR TITLE
fix(tests): Add contains_over_clause #848

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Changelog
 
 (Unreleased)
 ~~~~~~~~~~~~
+* Add Django 4.2 support (no code changes were needed, but now we test this release).
+* Fix failing tests as per issue #848
+  Added `contains_over_clause` to `ExtraJoinRestriction`.
 
 3.1.0 (2022-11-08)
 ~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -33,6 +33,8 @@ class ExtraJoinRestriction:
     """
 
     contains_aggregate = False
+    # Added for Django >= 4.2
+    contains_over_clause = False
 
     def __init__(self, alias, col, content_types):
         self.alias = alias

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
     isort
     py{36,37,38,39,310}-dj32
     py{38,39,310}-dj40
-    py{38,39,310,311}-dj{41,main}
+    py{38,39,310,311}-dj41
+    py{310,311}-dj{42,main}
     docs
 
 [gh-actions]
@@ -23,6 +24,7 @@ deps =
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     djangorestframework


### PR DESCRIPTION
Added support for Django 4.2

Adding support for Django 4.2 broke some tests with this error `AttributeError: 'ExtraJoinRestriction' object has no attribute 'contains_over_clause'`

Tracking the source of the error I have found a change to `38  def split_having(self, negated=False):` in  [django 4.1](https://github.com/django/django/blob/stable/4.1.x/django/db/models/sql/where.py) 
to  `38 def split_having_qualify(self, negated=False, must_group_by=False):` in [django 4.2](https://github.com/django/django/blob/stable/4.2.x/django/db/models/sql/where.py) which is causing the error.

The[ `'contains_over_clause'`](https://docs.djangoproject.com/en/4.2/ref/models/expressions/#expression-api)  Attribute Tells Django that this expression contains a [Window](https://docs.djangoproject.com/en/4.2/ref/models/expressions/#django.db.models.expressions.Window) expression. It’s used, for example, to disallow window function expressions in queries that modify data. 
Examples of what the OVER clause does can be seen in the [postgres documentation](https://www.postgresql.org/docs/current/tutorial-window.html#:~:text=The%20OVER%20clause%20determines%20exactly,PARTITION%20BY%20expression(s).).

Adding `contains_over_clause = False` to `ExtraJoinRestriction` allows the tests to run successfully.

closes #848 