### PR TITLE
Update minimal dependency version of Django to 4.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ project_urls =
 [options]
 python_requires = >=3.6
 packages = find:
-install_requires = Django>=3.2
+install_requires = Django>=4.1
 include_package_data = true
 zip_safe = false
 


### PR DESCRIPTION
This is in line with the current test matrix. Fixes #875