### PR TITLE
Prepare v5.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+5.0.1 (2023-10-26)
+~~~~~~~~~~~~~~~~~~
+
+* Fix the package metadata to properly reflect the right Django and Python version requirements
+  Release 5.0.0 improperly stated its Django bounds as >=3.2, so people installing without bounds will end up on a version that won't work.
+
 5.0.0 (2023-10-24)
 ~~~~~~~~~~~~~~~~~~
 * **Backwards icompatible:** Rename the (``content_type``, ``object_id``) index on ``TaggedItem``.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,6 +89,7 @@ These steps need to happen by a release maintainer.
 
 To make a release, the following needs to happen:
 
+- Make sure that ``setup.cfg`` is set up properly w/r/t Python and Django requirements
 - Bump the version number in ``taggit/__init__.py``
 - Update the changelog (making sure to add the (Unreleased) section to the top)
 - Get those changes onto the ``master`` branch

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,17 +11,14 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -32,9 +29,9 @@ project_urls =
     Tracker = https://github.com/jazzband/django-taggit/issues
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 packages = find:
-install_requires = Django>=3.2
+install_requires = Django>=4.1
 include_package_data = true
 zip_safe = false
 


### PR DESCRIPTION
This just tags the requirements properly.

@jezdez I think we want to yank 5.0.0 (after I release 5.0.!), just because Django 3.2 is an LTS release so until mid-2024. Is there a process that would allow me to do yanking on Pypi?