### PR TITLE
Updating Test suite with py312

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+5.0.2 (2024-06-19)
+~~~~~~~~~~~~~~~~~~
+
+* Update `tox.ini` for testing suite to now use Python 3.12.
+  
+  **Note:** Python 3.8 will be reaching end-of-life status in October 2024, we will need to come back and remove support for Python 3.8 at that time.
+
 5.0.1 (2023-10-26)
 ~~~~~~~~~~~~~~~~~~
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     black
     flake8
     isort
-    py{38,39,310,311}-dj{41,42}
-    py{310,311}-djmain
+    py{38,39,310,311,312}-dj{41,42}
+    py{310,311,312}-djmain
     docs
 
 [gh-actions]
@@ -14,6 +14,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 deps =


### PR DESCRIPTION
# Overview
This PR is for issue #895:

- Utilized the django python compatibility chart located here: 
    - https://docs.djangoproject.com/en/5.0/faq/install/

**Note:**
- Python 3.8 will reach EoL status in 10/2024, we can create a new issue and forward date it to October to remind us
- Context: https://devguide.python.org/versions/