### PR TITLE
894 - Add django 5.0 Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
   If you wish to have the old behavior, set ``ordering=[]`` to your ``TaggableManager`` instance.
   We believe that this should not cause a noticable performance change, and the number of queries involved should not change.
 
+5.0.2 (2024-06-19)
+~~~~~~~~~~~~~~~~~~
+* Add Django 5.0 support (no code changes were needed, but now we test this release).
+
 5.0.1 (2023-10-26)
 ~~~~~~~~~~~~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,6 @@ Changelog
   The previous behavior for this was that by default tag items were not ordered. In practice tag items often end up ordered by creation date anyways, just due to how databases work, but this was not a guarantee.
   If you wish to have the old behavior, set ``ordering=[]`` to your ``TaggableManager`` instance.
   We believe that this should not cause a noticable performance change, and the number of queries involved should not change.
-
-5.0.2 (2024-06-19)
-~~~~~~~~~~~~~~~~~~
 * Add Django 5.0 support (no code changes were needed, but now we test this release).
 
 5.0.1 (2023-10-26)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     black
     flake8
     isort
-    py{38,39,310,311}-dj{41,42}
+    py{38,39,310,311}-dj{41,42,50}
     py{310,311}-djmain
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ python =
 deps =
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
+    dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     coverage
     djangorestframework

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     black
     flake8
     isort
-    py{38,39,310,311}-dj{41,42,50}
+    py{38,39,310,311}-dj{41,42}
+    py{310,311}-dj{50}
     py{310,311}-djmain
     docs
 


### PR DESCRIPTION
#894 

Adds support for Django 5.0 for python versions >= 3.10.  

Django 5.0 only supports python 3.10, 3.11 and 3.12 currently - [Django Compatibility]( https://docs.djangoproject.com/en/5.0/releases/5.0/#python-compatibility
)


[Django release Notes](https://docs.djangoproject.com/en/5.0/releases/5.0/)