### PR TITLE
[#682] - Remove Orphaned Tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 (Unreleased)
 ~~~~~~~~~~~~
+* Added a management command (``remove_orphaned_tags``) to remove orphaned tags
 
 6.0.0 (2024-07-27)
 ~~~~~~~~~~~~~~~~~~

--- a/taggit/management/commands/remove_orphaned_tags.py
+++ b/taggit/management/commands/remove_orphaned_tags.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from taggit.models import Tag
+
+
+class Command(BaseCommand):
+    help = "Remove orphaned tags"
+
+    def handle(self, *args, **options):
+        orphaned_tags = Tag.objects.filter(taggit_taggeditem_items=None)
+        count = orphaned_tags.count()
+        orphaned_tags.delete()
+        self.stdout.write(f"Successfully removed {count} orphaned tags")

--- a/taggit/management/commands/remove_orphaned_tags.py
+++ b/taggit/management/commands/remove_orphaned_tags.py
@@ -8,6 +8,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         orphaned_tags = Tag.objects.filter(taggit_taggeditem_items=None)
-        count = orphaned_tags.count()
-        orphaned_tags.delete()
+        count = orphaned_tags.delete()
         self.stdout.write(f"Successfully removed {count} orphaned tags")

--- a/tests/test_remove_orphaned_tags.py
+++ b/tests/test_remove_orphaned_tags.py
@@ -1,0 +1,58 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from taggit.models import Tag
+from tests.models import Food, HousePet
+
+
+class RemoveOrphanedTagsTests(TestCase):
+    def setUp(self):
+        # Create some tags, some orphaned and some not
+        self.orphan_tag1 = Tag.objects.create(name="Orphan1")
+        self.orphan_tag2 = Tag.objects.create(name="Orphan2")
+        self.used_tag = Tag.objects.create(name="Used")
+
+        # Create instances of Food and HousePet and tag them
+        self.food_item = Food.objects.create(name="Apple")
+        self.pet_item = HousePet.objects.create(name="Fido")
+
+        self.food_item.tags.add(self.used_tag)
+        self.pet_item.tags.add(self.used_tag)
+
+    def test_remove_orphaned_tags(self):
+        # Ensure the setup is correct
+        self.assertEqual(Tag.objects.count(), 3)
+        self.assertEqual(Tag.objects.filter(taggit_taggeditem_items=None).count(), 2)
+
+        # Call the management command to remove orphaned tags
+        call_command("remove_orphaned_tags")
+
+        # Check the count of tags after running the command
+        self.assertEqual(Tag.objects.count(), 1)
+        self.assertEqual(Tag.objects.filter(taggit_taggeditem_items=None).count(), 0)
+
+        # Ensure that the used tag still exists
+        self.assertTrue(Tag.objects.filter(name="Used").exists())
+        self.assertFalse(Tag.objects.filter(name="Orphan1").exists())
+        self.assertFalse(Tag.objects.filter(name="Orphan2").exists())
+
+    def test_no_orphaned_tags(self):
+        # Ensure the setup is correct
+        self.assertEqual(Tag.objects.count(), 3)
+        self.assertEqual(Tag.objects.filter(taggit_taggeditem_items=None).count(), 2)
+
+        # Add used_tag to food_item to make no tags orphaned
+        self.food_item.tags.add(self.orphan_tag1)
+        self.food_item.tags.add(self.orphan_tag2)
+
+        # Call the management command to remove orphaned tags
+        call_command("remove_orphaned_tags")
+
+        # Check the count of tags after running the command
+        self.assertEqual(Tag.objects.count(), 3)
+        self.assertEqual(Tag.objects.filter(taggit_taggeditem_items=None).count(), 0)
+
+        # Ensure all tags still exist
+        self.assertTrue(Tag.objects.filter(name="Used").exists())
+        self.assertTrue(Tag.objects.filter(name="Orphan1").exists())
+        self.assertTrue(Tag.objects.filter(name="Orphan2").exists())


### PR DESCRIPTION
# Overview
- This PR handles removing orphaned tags
- This is connected to PR #904 and pertains to issue #682. 
- I branched this off of my #904 branch since they were related but I can do a fresh PR if needed.

## Updates
- `CHANGELOG.rst`
- `taggit/management/commands/remove_orphaned_tags.py`

## Manual Test
- Pull code down locally
- `pip install -e location_of_your_app/django-taggit`
- run `python manage.py remove_orphaned_tags` inside of your sample_app

## Reference
- https://docs.djangoproject.com/en/5.0/howto/custom-management-commands/


## Preview
https://www.loom.com/share/0c2b3f0b2dab4d7da9d2943f1520e12e?sid=98d050f0-3046-4aee-b2ec-78945b2a5408