### PR TITLE
Removing 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
 
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~
 
 * Add an admin command to remove orphaned tags
+* Remove support for Python 3.8
 
 6.1.0 (2024-09-29)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to django-taggit's documentation!
 ``django-taggit`` is a reusable Django application designed to make adding
 tagging to your project easy and fun.
 
-``django-taggit`` works with Django 4.1+ and Python 3.8+.
+``django-taggit`` works with Django 4.1+ and Python 3.9+.
 
 .. toctree::
    :maxdepth: 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -31,7 +30,7 @@ project_urls =
     Tracker = https://github.com/jazzband/django-taggit/issues
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 packages = find:
 install_requires = Django>=4.1
 include_package_data = true

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (6, 1, 1)
+VERSION = (6, 1, 0)
 __version__ = ".".join(str(i) for i in VERSION)

--- a/taggit/__init__.py
+++ b/taggit/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (6, 1, 0)
+VERSION = (6, 1, 1)
 __version__ = ".".join(str(i) for i in VERSION)

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,14 @@ envlist =
     black
     flake8
     isort
-    py{38,39,310,311,312}-dj{41,42}
+    py{39,310,311,312}-dj{41,42}
     py{310,311,312}-dj{50}
     py{310,311,312}-djmain
     docs
 
 [gh-actions]
 python =
-    3.8: py38, black, flake8, isort
-    3.9: py39
+    3.9: py39, black, flake8, isort
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Overview:
This PR is mainly for cleanup. Now that Python 3.8 has officially reached EoL, it is time to remove support for that version.
This refers to #900

Updates:
These 2 are probably the most important for review since they handle CI/CD workflows
- `.github/workflows/release.yml`
- `.github/workflows/test.yml`

########################

- `CHANGELOG.rst`
- `docs/index.rst`
- `setup.cfg`
- `taggit/__init__.py`
- `tox.ini`