### PR TITLE
Fix bug with merge form action when querystring is present.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 * Add an admin command to remove orphaned tags
 * Remove support for Python 3.8
-* Replace `request.get_full_path()` with `request.path` for merge form action
+* Fix an issue where the admin merge tag form redirect would fail when querystrings are present inside the URL
 
 6.1.0 (2024-09-29)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Add an admin command to remove orphaned tags
 * Remove support for Python 3.8
+* Replace `request.get_full_path()` with `request.path` for merge form action
 
 6.1.0 (2024-09-29)
 ~~~~~~~~~~~~~~~~~~

--- a/taggit/admin.py
+++ b/taggit/admin.py
@@ -40,7 +40,7 @@ class TagAdmin(admin.ModelAdmin):
             return redirect(request.get_full_path())
 
         selected_tag_ids = ",".join(selected)
-        redirect_url = f"{request.get_full_path()}merge-tags/"
+        redirect_url = f"{request.path}merge-tags/"
 
         request.session["selected_tag_ids"] = selected_tag_ids
 

--- a/taggit/admin.py
+++ b/taggit/admin.py
@@ -39,12 +39,11 @@ class TagAdmin(admin.ModelAdmin):
             self.message_user(request, "Please select at least one tag.")
             return redirect(request.get_full_path())
 
+        # set the selected tags into the session, to be used later
         selected_tag_ids = ",".join(selected)
-        redirect_url = f"{request.path}merge-tags/"
-
         request.session["selected_tag_ids"] = selected_tag_ids
 
-        return redirect(redirect_url)
+        return redirect("admin:taggit_tag_merge_tags")
 
     def merge_tags_view(self, request):
         selected_tag_ids = request.session.get("selected_tag_ids", "").split(",")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -59,6 +59,7 @@ class AdminTest(TestCase):
         )
         # we're redirecting
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:taggit_tag_merge_tags"))
         # make sure what we expected got into the session keys
         assert "selected_tag_ids" in self.client.session.keys()
         self.assertEqual(


### PR DESCRIPTION
Querystrings are preventing the tags from merging, because `get_full_path()` in the redirect preserves querystrings.

**Steps to reproduce**

1. Load the admin area > Taggit > Tags
2. Sort by `slug` so that the path is `/admin/taggit/tag/?o=2.1` (with querystring)
3. Select two tags, eg: "Adventure" and "Anthology, then action "Merge selected tags"

**Result**

Because the resulting path is `/admin/taggit/tag/?o=2.1merge-tags/` you stay on the listing page.

This also affects paging querystrings.

**Fix**

Use `request.path` instead of `request.get_full_path()`.