### PR TITLE
Add strict parameter to remove() TaggableManager.remove() method (fixes #928)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Add ``strict`` parameter to ``TaggableManager.remove()`` method. When ``strict=True``,
+  a ``ValueError`` is raised if any of the specified tags are not associated with the object.
+  Default behavior (``strict=False``) remains unchanged for backwards compatibility.
 * Add an admin command to remove orphaned tags
 * Remove support for Python 3.8
 * Fix an issue where the admin merge tag form redirect would fail when querystrings are present inside the URL

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,10 +27,21 @@ playing around with the API.
         The ``tag_kwargs`` argument allows one to specify parameters for the tags
         themselves.
 
-    .. method:: remove(*tags)
+    .. method:: remove(*tags, strict=False)
 
-        Removes a tag from an object. No exception is raised if the object
-        doesn't have that tag.
+        Removes tags from an object.
+
+        :param tags: Tag names (strings) or Tag instances to remove.
+        :param strict: If ``True``, raises ``ValueError`` when any of the
+            specified tags are not associated with this object. If ``False``
+            (default), silently ignores tags that don't exist on this object.
+
+        Example::
+
+            >>> apple.tags.add("red", "green")
+            >>> apple.tags.remove("red")  # Works, removes "red"
+            >>> apple.tags.remove("blue")  # Silently ignored (default)
+            >>> apple.tags.remove("blue", strict=True)  # Raises ValueError
 
     .. method:: clear()
 

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -346,7 +346,19 @@ class _TaggableManager(models.Manager):
             self.add(*new_objs, through_defaults=through_defaults, **kwargs)
 
     @require_instance_manager
-    def remove(self, *tags):
+    def remove(self, *tags, strict=False):
+        """
+        Remove tags from the object.
+
+        Args:
+            *tags: Tag names (strings) or Tag objects to remove.
+            strict: If True, raise ValueError when any of the specified tags
+                are not associated with this object. If False (default),
+                silently ignore tags that don't exist on this object.
+
+        Raises:
+            ValueError: When strict=True and any tags are not found on this object.
+        """
         if not tags:
             return
 
@@ -360,6 +372,17 @@ class _TaggableManager(models.Manager):
         )
 
         old_ids = set(qs.values_list("tag_id", flat=True))
+
+        if strict:
+            # Get the tag names that were actually found
+            found_tag_names = set(qs.values_list("tag__name", flat=True))
+            requested_tag_names = set(tags)
+            missing_tags = requested_tag_names - found_tag_names
+            if missing_tags:
+                missing_str = ", ".join(sorted(missing_tags))
+                raise ValueError(
+                    f"The following tags are not associated with this object: {missing_str}"
+                )
 
         signals.m2m_changed.send(
             sender=self.through,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -349,6 +349,47 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             ]
         )
 
+    def test_remove_nonexistent_tag_silent_by_default(self):
+        """Test that removing a non-existent tag does not raise an error by default."""
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("red", "green")
+
+        # Should not raise - this is the default behavior for backwards compatibility
+        apple.tags.remove("nonexistent")
+        self.assertEqual(sorted(apple.tags.names()), ["green", "red"])
+
+    def test_remove_nonexistent_tag_strict_raises_error(self):
+        """Test that removing a non-existent tag raises ValueError when strict=True."""
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("red", "green")
+
+        with self.assertRaises(ValueError) as cm:
+            apple.tags.remove("blue", strict=True)
+
+        self.assertIn("blue", str(cm.exception))
+        # Tags should be unchanged
+        self.assertEqual(sorted(apple.tags.names()), ["green", "red"])
+
+    def test_remove_existing_tag_strict_succeeds(self):
+        """Test that removing an existing tag works normally with strict=True."""
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("red", "green")
+
+        apple.tags.remove("red", strict=True)
+        self.assertEqual(list(apple.tags.names()), ["green"])
+
+    def test_remove_mixed_tags_strict_raises_error(self):
+        """Test that removing a mix of existing and non-existing tags raises error with strict=True."""
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("red", "green")
+
+        with self.assertRaises(ValueError) as cm:
+            apple.tags.remove("red", "purple", strict=True)
+
+        self.assertIn("purple", str(cm.exception))
+        # Tags should be unchanged since the operation failed
+        self.assertEqual(sorted(apple.tags.names()), ["green", "red"])
+
     @mock.patch("django.db.models.signals.m2m_changed.send")
     def test_clear_sends_m2m_changed_signal(self, send_mock):
         apple = self.food_model.objects.create(name="apple")


### PR DESCRIPTION
## Summary
Fixes #928

This PR adds an optional strict parameter to the `TaggableManager.remove()` method, allowing users to opt-in to receiving an error when attempting to remove tags that are not associated with the object.

## Changes
`managers.py`: Added `strict=False` parameter to `remove()` method. When `strict=True`, raises ValueError listing any tags not found on the object.
`tests.py`: Added 4 test cases covering the new functionality.
`CHANGELOG.rst`: Added entry for the new feature.
`api.rst`: Updated documentation with the new parameter.

## Behaviour
```
# Default behavior (backwards compatible) - silently ignores missing tags
apple.tags.add("red", "green")
apple.tags.remove("blue")  # No error, nothing happens

# Strict mode - raises ValueError for missing tags
apple.tags.remove("blue", strict=True)  
# ValueError: The following tags are not associated with this object: blue
```