### PR TITLE
Move verbose_name and verbose_name_plural from TaggedItem to ItemBase

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -142,6 +142,8 @@ class ItemBase(NaturalKeyModel):
     objects = NaturalKeyManager()
 
     class Meta:
+        verbose_name = _("tagged item")
+        verbose_name_plural = _("tagged items")
         abstract = True
 
     @classmethod
@@ -229,8 +231,6 @@ class GenericUUIDTaggedItemBase(CommonGenericTaggedItemBase):
 
 class TaggedItem(GenericTaggedItemBase, TaggedItemBase):
     class Meta:
-        verbose_name = _("tagged item")
-        verbose_name_plural = _("tagged items")
         app_label = "taggit"
         indexes = [
             models.Index(


### PR DESCRIPTION
This PR addresses #158.

It moves the verbose_name and verbose_name_plural attributes from TaggedItem to ItemBase.

All classes inheriting from ItemBase (including GenericTaggedItemBase and TaggedItemBase) will now automatically have these attributes.
This avoids the need for developers to redefine them in custom subclasses, solving the reported issue.

No change in existing behavior for TaggedItem itself, since the default values remain the same.