### PR TITLE
Add support for removing tags by slug

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import MultipleObjectsReturned
 from django.db import connections, models, router
-from django.db.models import signals,Q
+from django.db.models import signals, Q
 from django.db.models.fields.related import (
     ManyToManyRel,
     OneToOneRel,
@@ -356,7 +356,7 @@ class _TaggableManager(models.Manager):
         qs = (
             self.through._default_manager.using(db)
             .filter(**self._lookup_kwargs())
-            .filter(Q(tag__name__in=tags)|Q(tag__slug__in=tags))
+            .filter(Q(tag__name__in=tags) | Q(tag__slug__in=tags))
         )
 
         old_ids = set(qs.values_list("tag_id", flat=True))

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import MultipleObjectsReturned
 from django.db import connections, models, router
-from django.db.models import signals, Q
+from django.db.models import Q, signals
 from django.db.models.fields.related import (
     ManyToManyRel,
     OneToOneRel,
@@ -356,8 +356,14 @@ class _TaggableManager(models.Manager):
         qs = (
             self.through._default_manager.using(db)
             .filter(**self._lookup_kwargs())
-            .filter(Q(tag__name__in=tags) | Q(tag__slug__in=tags))
         )
+
+        name_matches = qs.filter(tag__name__in=tags)
+
+        if name_matches.exists():
+            qs = name_matches
+        else:
+            qs = qs.filter(tag__slug__in=tags)
 
         old_ids = set(qs.values_list("tag_id", flat=True))
 

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -353,10 +353,7 @@ class _TaggableManager(models.Manager):
         self._remove_prefetched_objects()
         db = router.db_for_write(self.through, instance=self.instance)
 
-        qs = (
-            self.through._default_manager.using(db)
-            .filter(**self._lookup_kwargs())
-        )
+        qs = self.through._default_manager.using(db).filter(**self._lookup_kwargs())
 
         name_matches = qs.filter(tag__name__in=tags)
 

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import MultipleObjectsReturned
 from django.db import connections, models, router
-from django.db.models import signals
+from django.db.models import signals,Q
 from django.db.models.fields.related import (
     ManyToManyRel,
     OneToOneRel,
@@ -356,7 +356,7 @@ class _TaggableManager(models.Manager):
         qs = (
             self.through._default_manager.using(db)
             .filter(**self._lookup_kwargs())
-            .filter(tag__name__in=tags)
+            .filter(Q(tag__name__in=tags)|Q(tag__slug__in=tags))
         )
 
         old_ids = set(qs.values_list("tag_id", flat=True))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -348,6 +348,14 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 ),
             ]
         )
+    
+    def test_remove_tag_by_slug(self):
+        apple_pie = self.food_model.objects.create(name='apple pie')
+        apple_pie.tags.add("apple pie")
+        slug = apple_pie.tags.first().slug
+        apple_pie.tags.remove(slug)
+        self.assertEqual(apple_pie.tags.count(),0)
+        self.assertFalse(apple_pie.tags.exists(),False)
 
     @mock.patch("django.db.models.signals.m2m_changed.send")
     def test_clear_sends_m2m_changed_signal(self, send_mock):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -355,7 +355,7 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
         slug = apple_pie.tags.first().slug
         apple_pie.tags.remove(slug)
         self.assertEqual(apple_pie.tags.count(), 0)
-        self.assertFalse(apple_pie.tags.exists(), False)
+        self.assertFalse(apple_pie.tags.exists())
 
     @mock.patch("django.db.models.signals.m2m_changed.send")
     def test_clear_sends_m2m_changed_signal(self, send_mock):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -348,14 +348,14 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
                 ),
             ]
         )
-    
+
     def test_remove_tag_by_slug(self):
-        apple_pie = self.food_model.objects.create(name='apple pie')
+        apple_pie = self.food_model.objects.create(name="apple pie")
         apple_pie.tags.add("apple pie")
         slug = apple_pie.tags.first().slug
         apple_pie.tags.remove(slug)
-        self.assertEqual(apple_pie.tags.count(),0)
-        self.assertFalse(apple_pie.tags.exists(),False)
+        self.assertEqual(apple_pie.tags.count(), 0)
+        self.assertFalse(apple_pie.tags.exists(), False)
 
     @mock.patch("django.db.models.signals.m2m_changed.send")
     def test_clear_sends_m2m_changed_signal(self, send_mock):


### PR DESCRIPTION
This PR addresses #151.

It adds support for removing tags by slug in TaggableManager.remove.

- Tags can now be removed using either name or slug
- Existing behavior is preserved (backward compatible)
- Includes tests for slug-based removal

No changes to existing functionality.