### PR TITLE
Add remove_by_slug() method to TaggableManager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Add a ``remove_by_slug()`` method to ``TaggableManager``, for removing a tag by its slug instead of its name
 * Add an admin command to remove orphaned tags
 * Remove support for Python 3.8
 * Remove support for Python 3.9

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,13 @@ playing around with the API.
         Removes a tag from an object. No exception is raised if the object
         doesn't have that tag.
 
+    .. method:: remove_by_slug(*slugs)
+
+        Removes a tag from an object by its slug rather than its name. This
+        is useful when only the slug is available, for example in a URL such
+        as ``.../some-object/tags/<slug>/remove/``. No exception is raised if
+        the object doesn't have a tag with that slug.
+
     .. method:: clear()
 
         Removes all tags from an object.

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -377,6 +377,51 @@ class _TaggableManager(models.Manager):
         )
 
     @require_instance_manager
+    def remove_by_slug(self, *slugs):
+        """
+        Removes tags from an object by their slug, instead of their name.
+
+        This is useful when the caller only has the slug on hand, e.g. when
+        building URLs like ``.../some-object/tags/<slug>/remove/``. Unlike
+        ``remove()``, this never matches on the tag name, so it behaves
+        correctly for custom tag models where names and slugs are not
+        guaranteed to be unique with respect to each other.
+        """
+        if not slugs:
+            return
+
+        self._remove_prefetched_objects()
+        db = router.db_for_write(self.through, instance=self.instance)
+
+        qs = (
+            self.through._default_manager.using(db)
+            .filter(**self._lookup_kwargs())
+            .filter(tag__slug__in=slugs)
+        )
+
+        old_ids = set(qs.values_list("tag_id", flat=True))
+
+        signals.m2m_changed.send(
+            sender=self.through,
+            action="pre_remove",
+            instance=self.instance,
+            reverse=False,
+            model=self.through.tag_model(),
+            pk_set=old_ids,
+            using=db,
+        )
+        qs.delete()
+        signals.m2m_changed.send(
+            sender=self.through,
+            action="post_remove",
+            instance=self.instance,
+            reverse=False,
+            model=self.through.tag_model(),
+            pk_set=old_ids,
+            using=db,
+        )
+
+    @require_instance_manager
     def clear(self):
         self._remove_prefetched_objects()
         db = router.db_for_write(self.through, instance=self.instance)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -349,6 +349,102 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             ]
         )
 
+    def test_remove_by_slug(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("green", "red")
+        green = self.tag_model.objects.get(name="green")
+
+        apple.tags.remove_by_slug(green.slug)
+
+        self.assert_tags_equal(apple.tags.all(), ["red"])
+
+    def test_remove_by_slug_unicode(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("café", "tea")
+        cafe = self.tag_model.objects.get(name="café")
+
+        apple.tags.remove_by_slug(cafe.slug)
+
+        self.assert_tags_equal(apple.tags.all(), ["tea"])
+
+    def test_remove_by_slug_nonexistent(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("green")
+
+        apple.tags.remove_by_slug("does-not-exist")
+
+        self.assert_tags_equal(apple.tags.all(), ["green"])
+
+    def test_remove_by_slug_no_args_is_noop(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("green")
+
+        apple.tags.remove_by_slug()
+
+        self.assert_tags_equal(apple.tags.all(), ["green"])
+
+    def test_remove_by_slug_is_case_sensitive(self):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("green")
+        green = self.tag_model.objects.get(name="green")
+        self.assertEqual(green.slug, "green")
+
+        apple.tags.remove_by_slug(green.slug.upper())
+
+        self.assert_tags_equal(apple.tags.all(), ["green"])
+
+    def test_remove_by_slug_does_not_match_by_name(self):
+        """
+        remove_by_slug() must only ever match on the slug field, even when a
+        different tag happens to share that string as its name. This guards
+        against the ambiguity that sank the earlier attempt at this feature
+        (name-or-slug filtering could delete the wrong tag relation, see
+        #151 and #939).
+        """
+        apple = self.food_model.objects.create(name="apple")
+        green_apple = self.tag_model.objects.create(name="Green Apple")
+        self.assertEqual(green_apple.slug, "green-apple")
+        name_collision = self.tag_model.objects.create(name="green-apple")
+        self.assertNotEqual(name_collision.slug, "green-apple")
+
+        apple.tags.add(green_apple, name_collision)
+        apple.tags.remove_by_slug("green-apple")
+
+        self.assert_tags_equal(apple.tags.all(), ["green-apple"], attr="name")
+
+    @mock.patch("django.db.models.signals.m2m_changed.send")
+    def test_remove_by_slug_sends_m2m_changed_signals(self, send_mock):
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("green")
+        green = self.tag_model.objects.get(name="green")
+        send_mock.reset_mock()
+
+        apple.tags.remove_by_slug(green.slug)
+
+        self.assertEqual(send_mock.call_count, 2)
+        send_mock.assert_has_calls(
+            [
+                mock.call(
+                    action="pre_remove",
+                    instance=apple,
+                    model=self.tag_model,
+                    pk_set={green.pk},
+                    reverse=False,
+                    sender=self.taggeditem_model,
+                    using="default",
+                ),
+                mock.call(
+                    action="post_remove",
+                    instance=apple,
+                    model=self.tag_model,
+                    pk_set={green.pk},
+                    reverse=False,
+                    sender=self.taggeditem_model,
+                    using="default",
+                ),
+            ]
+        )
+
     @mock.patch("django.db.models.signals.m2m_changed.send")
     def test_clear_sends_m2m_changed_signal(self, send_mock):
         apple = self.food_model.objects.create(name="apple")
@@ -900,6 +996,25 @@ class TenantTagTestCase(TestCase):
         self.assertEqual(self.tag_model.objects.all().count(), 4)
         self.assertEqual(tenant_1.tags.count(), 2)
         self.assertEqual(tenant_2.tags.count(), 2)
+
+    def test_remove_by_slug_scopes_to_the_tagged_instance(self):
+        # Different tenants can independently own a tag with the same slug,
+        # since slugs are only unique per tenant_id, not globally. Removing
+        # by slug on one instance must not affect the other tenant's tag.
+        tenant_1 = self.model.objects.create(name="tenant 1")
+        tenant_2 = self.model.objects.create(name="tenant 2")
+
+        tenant_1.tags.add("foo", tag_kwargs={"tenant_id": 1})
+        tenant_2.tags.add("foo", tag_kwargs={"tenant_id": 2})
+
+        tenant_1_foo = self.tag_model.objects.get(tenant_id=1, name="foo")
+        tenant_2_foo = self.tag_model.objects.get(tenant_id=2, name="foo")
+        self.assertEqual(tenant_1_foo.slug, tenant_2_foo.slug)
+
+        tenant_1.tags.remove_by_slug(tenant_1_foo.slug)
+
+        self.assertEqual(tenant_1.tags.count(), 0)
+        self.assertEqual(tenant_2.tags.count(), 1)
 
 
 class TaggableManagerOfficialTestCase(TaggableManagerTestCase):


### PR DESCRIPTION
Fixes #151.

## What changed

Adds a `remove_by_slug(*slugs)` method to `_TaggableManager`, as originally requested in #151, so tags can be removed using their slug (useful for URLs like `.../some-object/tags/<slug>/remove/`).

## Why a separate method instead of changing remove()

There was a previous attempt at this in #939, which instead widened `remove()` itself to match by name OR slug. Copilot's review on that PR flagged a real problem: for custom tag models where name and slug are not unique with respect to each other (for example one tag's name colliding with another tag's slug), the combined filter could delete the wrong tag relation. That PR was closed without merging.

This PR avoids that ambiguity entirely: `remove()` is untouched, and `remove_by_slug()` is a new, narrowly scoped method that only ever filters on `tag__slug__in`. It mirrors `remove()`'s implementation exactly, including sending the same `m2m_changed` `pre_remove`/`post_remove` signals with matching `sender`, `model`, and `pk_set` payloads, so any code listening for tag removal behaves identically regardless of whether the caller used a name or a slug.

## Tests

Added to `TaggableManagerTestCase`, so they run against every custom tag model variant already covered by the suite (Direct, CustomPK, Official, UUID, tracked):

* basic removal by slug
* unicode slug
* case sensitivity (exact match, like `remove()`)
* removing a nonexistent slug is a no-op, matching `remove()`'s documented behavior
* calling with no arguments is a no-op
* a regression test reproducing the exact name/slug collision scenario that #939 got flagged for, confirming `remove_by_slug()` never matches by name

Also added a test on `TenantTagTestCase`, confirming that when two tenants each own a tag with the same slug, removing by slug only affects the instance it was called on.

## Test result

Full `tox` run, all green:

```
black: OK
flake8: OK
isort: OK
py314-dj52: Ran 460 tests in 3.621s, OK (skipped=7)
py314-dj60: Ran 460 tests in 3.948s, OK (skipped=7)
docs: build succeeded
```

## Docs / changelog

* `docs/api.rst`: documented the new method alongside `remove()` and `clear()`.
* `CHANGELOG.rst`: added an entry under Unreleased.