### PR TITLE
Use the prefetch cache in TaggableManager.names()/slugs() (#936)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 (Unreleased)
 ~~~~~~~~~~~~
 
+* Fix ``TaggableManager.names()`` and ``slugs()`` issuing a query even when the tags were already loaded via ``prefetch_related``, causing N+1 selects (#936)
 * Add an admin command to remove orphaned tags
 * Remove support for Python 3.8
 * Remove support for Python 3.9

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -292,13 +292,26 @@ class _TaggableManager(models.Manager):
 
         return result
 
+    def _values_list(self, field):
+        # When the tags have been prefetched (e.g. via prefetch_related),
+        # read the field from the cached Tag objects instead of issuing a
+        # fresh values_list query that would bypass the prefetch cache and
+        # cause N+1 selects (#936).
+        try:
+            prefetched = self.instance._prefetched_objects_cache[
+                self.prefetch_cache_name
+            ]
+        except (AttributeError, KeyError):
+            return self.get_queryset().values_list(field, flat=True)
+        return [getattr(tag, field) for tag in prefetched]
+
     @require_instance_manager
     def names(self):
-        return self.get_queryset().values_list("name", flat=True)
+        return self._values_list("name")
 
     @require_instance_manager
     def slugs(self):
-        return self.get_queryset().values_list("slug", flat=True)
+        return self._values_list("slug")
 
     @require_instance_manager
     def set(self, tags, *, through_defaults=None, **kwargs):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -744,6 +744,24 @@ class TaggableManagerTestCase(BaseTaggingTestCase):
             foods = {f.name: {t.name for t in f.tags.all()} for f in list_prefetched}
             self.assertEqual(foods, {"orange": {"2", "4"}, "apple": {"1", "2"}})
 
+    def test_prefetch_related_names_and_slugs(self):
+        # names()/slugs() must use the prefetched tags instead of issuing a
+        # fresh query, avoiding N+1 selects. Regression test for #936.
+        apple = self.food_model.objects.create(name="apple")
+        apple.tags.add("1", "2")
+        orange = self.food_model.objects.create(name="orange")
+        orange.tags.add("2", "4")
+        with self.assertNumQueries(2):
+            list_prefetched = list(
+                self.food_model.objects.prefetch_related("tags").all()
+            )
+        with self.assertNumQueries(0):
+            names = {f.name: set(f.tags.names()) for f in list_prefetched}
+            self.assertEqual(names, {"orange": {"2", "4"}, "apple": {"1", "2"}})
+        with self.assertNumQueries(0):
+            slugs = {f.name: set(f.tags.slugs()) for f in list_prefetched}
+            self.assertEqual(slugs, {"orange": {"2", "4"}, "apple": {"1", "2"}})
+
     def test_prefetch_related_with_shared_tag(self):
         apple = self.food_model.objects.create(name="apple")
         apple.tags.add("shared", "apple-only")


### PR DESCRIPTION
Fixes #936

### Problem

`TaggableManager.names()` and `slugs()` call `get_queryset().values_list(...)`. Even when the tags were loaded via `prefetch_related`, `values_list()` clones the queryset and issues a **fresh** query, bypassing the prefetch cache and causing N+1 selects across a list of objects:

```python
list_prefetched = list(Food.objects.prefetch_related("tags").all())
# each of these hits the DB again, once per object:
{f.name: set(f.tags.names()) for f in list_prefetched}
```

### Fix

When the relation is prefetched (present in `instance._prefetched_objects_cache`), read `name` / `slug` directly from the cached `Tag` objects. The non-prefetched path is unchanged.

### Tests

Added `test_prefetch_related_names_and_slugs` (based on the reproduction in the issue), asserting `names()` and `slugs()` execute **0** queries when the tags are prefetched. It fails on the default branch (2 queries) and passes with this change. `black` clean; changelog updated. (The pre-existing `UUIDFood` ordering failure and the `rest_framework` import error are unrelated.)