### PR TITLE
Never save a Tag with a blank slug

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -80,14 +80,22 @@ class TagBase(NaturalKeyModel):
             # with a multi-master setup, theoretically we could try to
             # write and rollback on different DBs
             kwargs["using"] = using
-            # Be opportunistic and try to save the tag, this should work for
-            # most cases ;)
-            try:
-                with transaction.atomic(using=using):
-                    res = super().save(*args, **kwargs)
-                return res
-            except IntegrityError:
-                pass
+            # A name made up entirely of characters that slugify() strips
+            # (e.g. "@") produces an empty slug. Treat that the same as an
+            # existing-slug collision below, rather than ever saving a
+            # blank slug: skip the initial optimistic save attempt and go
+            # straight to the numbered-suffix fallback loop, so every such
+            # tag consistently gets a non-empty slug like "_1", "_2", ...
+            # instead of only the *second* one onwards. See GH #393.
+            if self.slug:
+                # Be opportunistic and try to save the tag, this should work
+                # for most cases ;)
+                try:
+                    with transaction.atomic(using=using):
+                        res = super().save(*args, **kwargs)
+                    return res
+                except IntegrityError:
+                    pass
             # Now try to find existing slugs with similar names
             slugs = set(
                 type(self)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -90,6 +90,27 @@ class TagModelTestCase(BaseTaggingTestCase):
         apple = self.food_model.objects.create(name="apple")
         apple.tags.add("Red", "red")
 
+    def test_no_blank_slug_for_unslugifiable_name(self):
+        """
+        Regression test for
+        https://github.com/jazzband/django-taggit/issues/393
+
+        A tag name made up entirely of characters stripped by
+        slugify() (e.g. "@") must not be saved with a blank slug --
+        including the very first such tag created, not just
+        subsequent ones that happen to collide with an existing blank
+        slug.
+        """
+        first = self.tag_model.objects.create(name="@")
+        second = self.tag_model.objects.create(name="#")
+        third = self.tag_model.objects.create(name="%")
+
+        for tag in (first, second, third):
+            assert tag.slug, f"tag {tag.name!r} was saved with a blank slug"
+
+        slugs = {first.slug, second.slug, third.slug}
+        assert len(slugs) == 3, f"slugs must all be unique, got {slugs}"
+
     def test_update(self):
         special = self.tag_model.objects.create(name="special")
         special.save()


### PR DESCRIPTION
Fixes #393.

`TagBase.save()` computed `self.slug = self.slugify(self.name)`, then optimistically tried to save; only on an `IntegrityError` (an existing slug collision) did it fall back to the numbered-suffix loop (`slugify(name, i)` -> `"..._1"`, `"..._2"`, etc.) to find a free slug.

A tag name made up entirely of characters that `slugify()` strips (most commonly punctuation-only names like `"@"` or `"#"`) produces an empty string. The first such tag ever created has no existing blank-slug row to collide with, so the optimistic save succeeds with `slug=""` and stays that way permanently. Only the *second* punctuation-only tag triggers the collision path and gets a suffixed slug like `"_1"` -- the first one is left with a genuinely blank slug, exactly as reported in the issue.

**Fix**: treat an empty `slugify()` result the same way an existing collision is already treated: skip the optimistic save attempt and go straight to the numbered-suffix fallback loop. This reuses the existing mechanism rather than adding a new one, and makes every punctuation-only tag -- including the first -- consistently get a non-empty, unique slug like `"_1"`, `"_2"`, etc.

**Testing**: verified with a real Django + django-taggit setup: before the fix, `Tag.objects.create(name="@")` produces `slug=""`; after the fix, it produces `slug="_1"`, and subsequent punctuation-only tags get `"_2"`, `"_3"`, etc. Confirmed normal tag names (including the existing same-name-different-case collision scenario) are completely unaffected.

Added a regression test creating three punctuation-only tags in a row and asserting none has a blank slug and all three are unique. I confirmed the test fails with the original code (first tag has a blank slug) and passes with the fix. Ran the full existing test suite (409 tests, all pass), no regressions.
