### PR TITLE
Fix: TagField.clean() in taggit/forms.py parsed tags via parse_tags(value)...

### DIFF
--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -36,9 +36,7 @@ class TagField(forms.CharField):
         for tag in tags:
             if len(tag) > max_tag_length:
                 raise forms.ValidationError(
-                    _(
-                        "Tag(s) %(tag)s are over %(max_tag_length)d characters"
-                    )
+                    _("Tag(s) %(tag)s are over %(max_tag_length)d characters")
                     % {"tag": tag, "max_tag_length": max_tag_length}
                 )
 

--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.utils.translation import gettext as _
 
+from taggit.models import Tag
 from taggit.utils import edit_string_for_tags, parse_tags
 
 
@@ -25,11 +26,23 @@ class TagField(forms.CharField):
     def clean(self, value):
         value = super().clean(value)
         try:
-            return parse_tags(value)
+            tags = parse_tags(value)
         except ValueError:
             raise forms.ValidationError(
                 _("Please provide a comma-separated list of tags.")
             )
+
+        max_tag_length = Tag._meta.get_field("name").max_length
+        for tag in tags:
+            if len(tag) > max_tag_length:
+                raise forms.ValidationError(
+                    _(
+                        "Tag(s) %(tag)s are over %(max_tag_length)d characters"
+                    )
+                    % {"tag": tag, "max_tag_length": max_tag_length}
+                )
+
+        return tags
 
     def has_changed(self, initial_value, data_value):
         # Always return False if the field is disabled since self.bound_data

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -60,3 +60,32 @@ class TagFieldTests(TestCase):
         form = TestForm()
 
         self.assertFalse(form.has_changed())
+
+
+class TagFieldMaxLengthTests(TestCase):
+    def test_should_return_error_on_clean_if_tag_exceeds_max_length(self):
+        class TestForm(forms.Form):
+            tag = TagField()
+
+        max_length = Tag._meta.get_field("name").max_length
+        too_long_tag = "x" * (max_length + 1)
+
+        form = TestForm({"tag": too_long_tag})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            f"Tag(s) {too_long_tag} are over {max_length} characters",
+            form.errors["tag"],
+        )
+
+    def test_should_be_valid_for_normal_length_tags(self):
+        class TestForm(forms.Form):
+            tag = TagField()
+
+        max_length = Tag._meta.get_field("name").max_length
+        ok_tag = "x" * max_length
+
+        form = TestForm({"tag": ok_tag})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["tag"], [ok_tag])


### PR DESCRIPTION
## Summary
TagField.clean() now reads max_tag_length = Tag._meta.get_field('name').max_length (sourced dynamically, not hardcoded) and iterates over the parsed tags, raising forms.ValidationError with a clear message ('Tag(s) %(tag)s are over %(max_tag_length)d characters') for any tag exceeding that length, before returning the parsed tags.

## Problem
jazzband/django-taggit issue reference: jazzband/django-taggit#872

## Root Cause
TagField.clean() in taggit/forms.py parsed tags via parse_tags(value) and returned them with no validation against the Tag model's name/slug max_length, allowing over-length tags to pass form validation and fail later at the database layer with an unhandled DataError instead of a clean ValidationError.

## Testing
PASS - all 7 tests in tests/test_forms.py pass (including the 2 new regression tests), and the full suite passes with 33 passed, 1 skipped.

## Related Issue
jazzband/django-taggit#872
