### PR TITLE
fix: handle non-string initial values in disabled TagField

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 * Add Django 5.2 and 6.0 support
 * Add Python 3.13 and 3.14 support
 * Fix an issue where the admin merge tag form redirect would fail when querystrings are present inside the URL
+* Fix disabled TagField incorrectly stringifying and parsing non-string initial values (such as model instances or lists of tags)
 
 6.1.0 (2024-09-29)
 ~~~~~~~~~~~~~~~~~~

--- a/taggit/forms.py
+++ b/taggit/forms.py
@@ -23,6 +23,16 @@ class TagField(forms.CharField):
     widget = TagWidget
 
     def clean(self, value):
+        if self.disabled:
+            if isinstance(value, str):
+                try:
+                    return parse_tags(super().clean(value))
+                except ValueError:
+                    raise forms.ValidationError(
+                        _("Please provide a comma-separated list of tags.")
+                    )
+            return [] if value is None else value
+
         value = super().clean(value)
         try:
             return parse_tags(value)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -60,3 +60,52 @@ class TagFieldTests(TestCase):
         form = TestForm()
 
         self.assertFalse(form.has_changed())
+
+    def test_disabled_field_with_model_instances(self):
+        class TestForm(forms.Form):
+            tag = TagField(disabled=True)
+
+        initial_tags = [Tag(name="apple"), Tag(name="banana")]
+        form = TestForm(initial={"tag": initial_tags}, data={"tag": "other"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["tag"], initial_tags)
+
+    def test_disabled_field_with_string_initial(self):
+        class TestForm(forms.Form):
+            tag = TagField(disabled=True)
+
+        form = TestForm(initial={"tag": "apple,banana"}, data={"tag": "other"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["tag"], ["apple", "banana"])
+
+    def test_disabled_field_with_none_initial(self):
+        class TestForm(forms.Form):
+            tag = TagField(disabled=True, required=False)
+
+        form = TestForm(initial={"tag": None}, data={"tag": "other"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["tag"], [])
+
+    def test_disabled_field_in_model_form(self):
+        from .forms import FoodForm
+        from .models import Food
+
+        food = Food.objects.create(name="Apple")
+        food.tags.add("red", "sweet")
+
+        form = FoodForm(
+            data={"name": "Green Apple", "tags": "green,sour"},
+            instance=food,
+        )
+        form.fields["tags"].disabled = True
+
+        self.assertTrue(form.is_valid())
+        saved_food = form.save()
+        self.assertEqual(saved_food.name, "Green Apple")
+        self.assertSequenceEqual(
+            saved_food.tags.order_by("name").values_list("name", flat=True),
+            ["red", "sweet"],
+        )


### PR DESCRIPTION
## Description

Fixes #943.

When a form field using `TagField` is set to `disabled=True`, Django's form handling passes the field's `initial` value directly into `clean(self, value)`.

For ModelForms (or forms where initial data is provided as a QuerySet or list of `Tag` model instances), `super().clean(value)` converts the list of tag instances into its string representation (`'[<Tag: apple>, <Tag: banana>]'`). This was subsequently parsed by `parse_tags()`, corrupting the tag names into strings like `'[<Tag: apple>'` and `'<Tag: banana>]'`.

## Changes

- In `taggit/forms.py`, updated `TagField.clean(self, value)`:
  - When `self.disabled` is `True`, if `value` is not a string, return `[] if value is None else value`.
  - If `value` is a string, clean and parse it normally.
- In `tests/test_forms.py`, added unit tests for:
  - Disabled `TagField` with a list of `Tag` model instances.
  - Disabled `TagField` with a string `initial` value.
  - Disabled `TagField` with `None` `initial` value.
  - Disabled `TagField` on a ModelForm (`FoodForm`), ensuring `form.save()` preserves the original model tags untouched.
- In `CHANGELOG.rst`, added an entry under `(Unreleased)`.

## Validation

- Ran `python -m django test --settings=tests.settings` (407 tests passed).
- Verified lint and code formatting with `black`, `flake8`, and `isort`.