### PR TITLE
docs: fix grammar in slugify_unicode_stripping_prep docstring

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -18,7 +18,7 @@ except ImportError:
 def slugify_unicode_stripping_prep(tag):
     """
     This handles stripping via unidecode if it's installed,
-    otherwise is a no-op
+    otherwise it is a no-op.
     """
     if unidecode_installed:
         return unidecode(tag)


### PR DESCRIPTION
### Summary
- Fix minor grammar phrasing in `slugify_unicode_stripping_prep` docstring (`otherwise is a no-op` -> `otherwise it is a no-op.`).