### PR TITLE
fix(managers): utilize prefetch cache in names() and slugs() (#936)

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -294,10 +294,16 @@ class _TaggableManager(models.Manager):
 
     @require_instance_manager
     def names(self):
+        prefetch_cache = getattr(self.instance, "_prefetched_objects_cache", None)
+        if prefetch_cache and self.prefetch_cache_name in prefetch_cache:
+            return [t.name for t in prefetch_cache[self.prefetch_cache_name]]
         return self.get_queryset().values_list("name", flat=True)
 
     @require_instance_manager
     def slugs(self):
+        prefetch_cache = getattr(self.instance, "_prefetched_objects_cache", None)
+        if prefetch_cache and self.prefetch_cache_name in prefetch_cache:
+            return [t.slug for t in prefetch_cache[self.prefetch_cache_name]]
         return self.get_queryset().values_list("slug", flat=True)
 
     @require_instance_manager

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,3 +104,12 @@ class TestPrefetchCache(TestCase):
 
         sample_obj.tags.clear()
         self.assertFalse(sample_obj.tags.is_cached(sample_obj))
+
+    def test_names_and_slugs_use_prefetch_cache(self):
+        """
+        Test that names() and slugs() utilize prefetch cache without additional DB queries
+        """
+        sample_obj = TestModel.objects.prefetch_related("tags").get()
+        with self.assertNumQueries(0):
+            self.assertEqual(set(sample_obj.tags.names()), {"1", "2", "3"})
+            self.assertEqual(set(sample_obj.tags.slugs()), {"1", "2", "3"})


### PR DESCRIPTION
Fixes #936

### Problem
Calling `.names()` or `.slugs()` on a `_TaggableManager` on model instances loaded via `prefetch_related("tags")` executed new SQL queries (`values_list()`) instead of leveraging the prefetched tags stored in memory in `_prefetched_objects_cache`. This resulted in unexpected N+1 query loops despite prefetching.

### Solution
- Updated `names()` and `slugs()` in `_TaggableManager` (`taggit/managers.py`) to inspect `_prefetched_objects_cache` on the instance and extract tag names/slugs directly from cached tag instances if available, avoiding extra DB queries.
- Retained standard queryset `values_list()` evaluation when prefetch cache is not present.
- Added unit test `test_names_and_slugs_use_prefetch_cache` to `TestPrefetchCache` in `tests/test_models.py` verifying 0 SQL queries are executed.
