### PR TITLE
Mark TaggableManager add/set/remove/clear with alters_data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 * Add Django 5.2 and 6.0 support
 * Add Python 3.13 and 3.14 support
 * Fix an issue where the admin merge tag form redirect would fail when querystrings are present inside the URL
+* Mark ``add``/``set``/``remove``/``clear`` on ``_TaggableManager`` with ``alters_data = True`` so templates cannot invoke them
 
 6.1.0 (2024-09-29)
 ~~~~~~~~~~~~~~~~~~

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -208,6 +208,8 @@ class _TaggableManager(models.Manager):
             using=db,
         )
 
+    add.alters_data = True
+
     def _to_tag_model_instances(self, tags, tag_kwargs):
         """
         Takes an iterable containing either strings, tag objects, or a mixture
@@ -340,6 +342,8 @@ class _TaggableManager(models.Manager):
             self.remove(*old_tag_strs)
             self.add(*new_objs, through_defaults=through_defaults, **kwargs)
 
+    set.alters_data = True
+
     @require_instance_manager
     def remove(self, *tags):
         if not tags:
@@ -376,6 +380,8 @@ class _TaggableManager(models.Manager):
             using=db,
         )
 
+    remove.alters_data = True
+
     @require_instance_manager
     def clear(self):
         self._remove_prefetched_objects()
@@ -402,6 +408,8 @@ class _TaggableManager(models.Manager):
             pk_set=None,
             using=db,
         )
+
+    clear.alters_data = True
 
     def most_common(self, min_count=None, extra_filters=None):
         queryset = (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,15 @@ class TestTaggableManager(TestCase):
         desired_result = ["green"]
         self.assertEqual(desired_result, [tag.name for tag in sample_obj.tags.all()])
 
+    def test_mutating_methods_mark_alters_data(self):
+        sample_obj = TestModel.objects.create()
+        for name in ("add", "set", "remove", "clear"):
+            method = getattr(sample_obj.tags, name)
+            self.assertTrue(
+                getattr(method, "alters_data", False),
+                f"{name} should be marked alters_data",
+            )
+
 
 class TestSlugification(TestCase):
     def test_unicode_slugs(self):


### PR DESCRIPTION
Fixes #953.

Django related managers set `alters_data = True` on methods that write, so templates won't call them. `_TaggableManager.add` / `set` / `remove` / `clear` were missing that, so a template lookup that landed on one of them could actually mutate tags.
