### PR TITLE
fix(utils): allow edit_string_for_tags to accept strings alongside Tag instances

### DIFF
--- a/taggit/utils.py
+++ b/taggit/utils.py
@@ -92,8 +92,8 @@ def split_strip(string, delimiter=","):
 
 def _edit_string_for_tags(tags):
     """
-    Given list of ``Tag`` instances, creates a string representation of
-    the list suitable for editing by the user, such that submitting the
+    Given a list of ``Tag`` instances or strings, creates a string representation
+    of the list suitable for editing by the user, such that submitting the
     given string representation back without changing it will give the
     same list of tags.
 
@@ -108,7 +108,7 @@ def _edit_string_for_tags(tags):
     """
     names = []
     for tag in tags:
-        name = tag.name
+        name = tag.name if hasattr(tag, "name") else str(tag)
         if "," in name or " " in name:
             names.append('"%s"' % name)
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import os.path
 from django.test import TestCase
 from django.utils import translation
 
-from taggit.utils import split_strip
+from taggit.utils import edit_string_for_tags, parse_tags, split_strip
 
 
 class SplitStripTests(TestCase):
@@ -33,3 +33,32 @@ class TestLanguages(TestCase):
             # attempt translation activation to confirm that the language files are working
             with translation.override(locale):
                 pass
+
+
+class EditStringForTagsTests(TestCase):
+    def test_with_tag_instances(self):
+        class DummyTag:
+            def __init__(self, name):
+                self.name = name
+
+        tags = [DummyTag("tag1"), DummyTag("tag with space"), DummyTag("tag,comma")]
+        self.assertEqual(edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1')
+
+    def test_with_strings(self):
+        tags = ["tag1", "tag with space", "tag,comma"]
+        self.assertEqual(edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1')
+
+    def test_with_empty_list(self):
+        self.assertEqual(edit_string_for_tags([]), "")
+
+
+class ParseTagsTests(TestCase):
+    def test_basic_parse(self):
+        self.assertEqual(parse_tags("foo, bar, baz"), ["bar", "baz", "foo"])
+
+    def test_quoted_tags(self):
+        self.assertEqual(parse_tags('"foo bar", baz'), ["baz", "foo bar"])
+
+    def test_empty_string(self):
+        self.assertEqual(parse_tags(""), [])
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,11 +42,15 @@ class EditStringForTagsTests(TestCase):
                 self.name = name
 
         tags = [DummyTag("tag1"), DummyTag("tag with space"), DummyTag("tag,comma")]
-        self.assertEqual(edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1')
+        self.assertEqual(
+            edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1'
+        )
 
     def test_with_strings(self):
         tags = ["tag1", "tag with space", "tag,comma"]
-        self.assertEqual(edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1')
+        self.assertEqual(
+            edit_string_for_tags(tags), '"tag with space", "tag,comma", tag1'
+        )
 
     def test_with_empty_list(self):
         self.assertEqual(edit_string_for_tags([]), "")
@@ -61,4 +65,3 @@ class ParseTagsTests(TestCase):
 
     def test_empty_string(self):
         self.assertEqual(parse_tags(""), [])
-


### PR DESCRIPTION
### Summary

- In `taggit.utils._edit_string_for_tags`, allow inputs to be either `Tag` instances or strings (`name = tag.name if hasattr(tag, 'name') else str(tag)`), avoiding `AttributeError` when string tag names are formatted.
- Update docstring to document support for strings alongside `Tag` instances.
- Add `EditStringForTagsTests` and `ParseTagsTests` in `tests/test_utils.py`.